### PR TITLE
Simplify signer set

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "ethers": "^5.6.1",
     "faker": "5.5.3",
     "log-update": "4.0.0",
-    "neverthrow": "^4.3.1"
+    "neverthrow": "^4.3.1",
+    "tiny-typed-emitter": "^2.1.0"
   },
   "lint-staged": {
     "*.ts": "eslint --cache --fix"

--- a/src/sets/signerSet.test.ts
+++ b/src/sets/signerSet.test.ts
@@ -10,13 +10,7 @@ const signerAdds = () => set._getSignerAdds();
 const signerRems = () => set._getSignerRemoves();
 
 let events: any[] = [];
-const eventNames: (keyof SignerSetEvents)[] = [
-  'addCustody',
-  'removeCustody',
-  'addSigner',
-  'removeSigner',
-  'revokeMessage',
-];
+const eventNames: (keyof SignerSetEvents)[] = ['addCustody', 'removeCustody', 'addSigner', 'removeSigner'];
 for (const eventName of eventNames) {
   set.addListener(eventName, (...args: any[]) => events.push([eventName, ...args]));
 }
@@ -235,7 +229,7 @@ describe('merge', () => {
         expect(events).toEqual([['addCustody', custody1.signerKey]]);
       });
 
-      test('succeeds and revokes messages signed by removed custody address', () => {
+      test('succeeds and removes signers added by removed custody address', () => {
         expect(set.merge(addA).isOk()).toBe(true);
         expect(set.addCustody(addCustody2).isOk()).toBe(true);
         expect(set.merge(removeAllCustody2).isOk()).toBe(true);
@@ -247,8 +241,8 @@ describe('merge', () => {
           ['addCustody', custody1.signerKey],
           ['addSigner', a.signerKey],
           ['addCustody', custody2.signerKey],
+          ['removeSigner', a.signerKey],
           ['removeCustody', custody1.signerKey],
-          ['revokeMessage', addA],
         ]);
       });
     });

--- a/src/sets/signerSet.test.ts
+++ b/src/sets/signerSet.test.ts
@@ -12,33 +12,55 @@ const signerRems = () => set._getSignerRemoves();
 
 let custody1: EthereumSigner;
 let addCustody1: CustodyAddEvent;
-let removeCustody1: CustodyRemoveAll;
+let removeAllCustody1: CustodyRemoveAll;
 let custody2: EthereumSigner;
 let addCustody2: CustodyAddEvent;
-let removeCustody2: CustodyRemoveAll;
+let removeAllCustody2: CustodyRemoveAll;
 let a: Ed25519Signer;
 let addA: SignerAdd;
 let remA: SignerRemove;
+let addA2: SignerAdd;
+let remA2: SignerRemove;
 let b: Ed25519Signer;
 let addB: SignerAdd;
 let c: Ed25519Signer;
 let addCToA: SignerAdd;
+let remAFromA: SignerRemove;
+let remBFromA: SignerRemove;
 
 beforeAll(async () => {
   custody1 = await generateEthereumSigner();
   addCustody1 = await Factories.CustodyAddEvent.create({}, { transient: { signer: custody1 } });
+  removeAllCustody1 = await Factories.CustodyRemoveAll.create({}, { transient: { signer: custody1 } });
   custody2 = await generateEthereumSigner();
-  addCustody2 = await Factories.CustodyAddEvent.create({}, { transient: { signer: custody2 } });
+  addCustody2 = await Factories.CustodyAddEvent.create(
+    { blockNumber: addCustody1.blockNumber + 1 },
+    { transient: { signer: custody2 } }
+  );
+  removeAllCustody2 = await Factories.CustodyRemoveAll.create({}, { transient: { signer: custody2 } });
   a = await generateEd25519Signer();
   addA = await Factories.SignerAdd.create({}, { transient: { signer: custody1, childSigner: a } });
   remA = await Factories.SignerRemove.create(
     { data: { body: { childKey: a.signerKey } } },
     { transient: { signer: custody1 } }
   );
+  addA2 = await Factories.SignerAdd.create({}, { transient: { signer: custody2, childSigner: a } });
+  remA2 = await Factories.SignerRemove.create(
+    { data: { body: { childKey: a.signerKey } } },
+    { transient: { signer: custody2 } }
+  );
   b = await generateEd25519Signer();
   addB = await Factories.SignerAdd.create({}, { transient: { signer: custody1, childSigner: b } });
   c = await generateEd25519Signer();
   addCToA = await Factories.SignerAdd.create({}, { transient: { signer: a, childSigner: c } });
+  remAFromA = await Factories.SignerRemove.create(
+    { data: { body: { childKey: a.signerKey } } },
+    { transient: { signer: a } }
+  );
+  remBFromA = await Factories.SignerRemove.create(
+    { data: { body: { childKey: b.signerKey } } },
+    { transient: { signer: a } }
+  );
 });
 
 beforeEach(() => {
@@ -50,6 +72,8 @@ describe('addCustody', () => {
     expect(set.addCustody(addCustody1).isOk()).toBe(true);
     expect(custodyAdds()).toEqual(new Map([[custody1.signerKey, addCustody1]]));
     expect(custodyRems()).toEqual(new Map());
+    expect(signerAdds()).toEqual(new Map());
+    expect(signerRems()).toEqual(new Map());
   });
 
   test('succeeds with multiple new custody addresses', () => {
@@ -62,396 +86,301 @@ describe('addCustody', () => {
       ])
     );
     expect(custodyRems()).toEqual(new Map());
+    expect(signerAdds()).toEqual(new Map());
+    expect(signerRems()).toEqual(new Map());
   });
 
-  // test('succeeds with a duplicate custody address (idempotent)', () => {
-  //   expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
-  //   expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
-  //   expect(custodyAddresses()).toEqual(new Set([custody1.signerKey]));
-  //   expect(vAdds()).toEqual(new Set());
-  //   expect(messageHashes()).toEqual(new Set());
-  // });
-  // test('fails when custody address is already a delegate', () => {
-  //   expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
-  //   expect(set.merge(addA).isOk()).toBe(true);
-  //   const res = set.addCustody(a.signerKey);
-  //   expect(res.isOk()).toBe(false);
-  //   expect(res._unsafeUnwrapErr()).toBe('SignerSet.addCustody: custodyAddress already exists as a delegate');
-  //   expect(custodyAddresses()).toEqual(new Set([custody1.signerKey]));
-  //   expect(vAdds()).toEqual(new Set([a.signerKey]));
-  //   expect(messageHashes()).toEqual(new Set([addA.hash]));
-  // });
-  // test('fails when custody address has already been removed', () => {
-  //   expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
-  //   expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
-  //   const res = set.addCustody(custody1.signerKey);
-  //   expect(res.isOk()).toBe(false);
-  //   expect(res._unsafeUnwrapErr()).toBe('SignerSet.addCustody: custodyAddress has been removed');
-  // });
-});
+  test('succeeds with a duplicate custody address (idempotent)', () => {
+    expect(set.addCustody(addCustody1).isOk()).toBe(true);
+    expect(set.addCustody(addCustody1).isOk()).toBe(true);
+    expect(custodyAdds()).toEqual(new Map([[custody1.signerKey, addCustody1]]));
+    expect(custodyRems()).toEqual(new Map());
+    expect(signerAdds()).toEqual(new Map());
+    expect(signerRems()).toEqual(new Map());
+  });
 
-describe('removeCustody', () => {
-  // test('fails when custody address does not exist', () => {
-  //   const res = set.removeCustody(custody1.signerKey);
-  //   expect(res.isOk()).toBe(false);
-  //   expect(res._unsafeUnwrapErr()).toBe('SignerSet.removeCustody: custodyAddress does not exist');
-  // });
-  // describe('with custody address', () => {
-  //   beforeEach(() => {
-  //     expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
-  //     expect(cAdds()).toEqual(new Set([custody1.signerKey]));
-  //     expect(cRems()).toEqual(new Set());
-  //   });
-  //   test('succeeds', () => {
-  //     expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
-  //     expect(cAdds()).toEqual(new Set());
-  //     expect(cRems()).toEqual(new Set([custody1.signerKey]));
-  //   });
-  //   test('succeeds and removes delegates', () => {
-  //     expect(set.merge(addA).isOk()).toBe(true);
-  //     expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
-  //     expect(cAdds()).toEqual(new Set());
-  //     expect(cRems()).toEqual(new Set([custody1.signerKey]));
-  //     expect(vAdds()).toEqual(new Set());
-  //     expect(vRems()).toEqual(new Set([a.signerKey]));
-  //     expect(eAddsHashes()).toEqual(new Set());
-  //     expect(eRemsHashes()).toEqual(new Set([addA.hash]));
-  //     expect(messageHashes()).toEqual(new Set([addA.hash]));
-  //   });
-  //   test('succeeds and removes delegates and subtrees', () => {
-  //     const messages = [addA, addB, addCToA];
-  //     for (const msg of messages) {
-  //       expect(set.merge(msg).isOk()).toBe(true);
-  //     }
-  //     expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
-  //     expect(cAdds()).toEqual(new Set());
-  //     expect(cRems()).toEqual(new Set([custody1.signerKey]));
-  //     expect(vAdds()).toEqual(new Set());
-  //     expect(vRems()).toEqual(new Set([a.signerKey, b.signerKey, c.signerKey]));
-  //     expect(eAddsHashes()).toEqual(new Set());
-  //     expect(eRemsHashes()).toEqual(new Set([addA.hash, addB.hash, addCToA.hash]));
-  //     expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-  //   });
-  // });
+  test('succeeds (no-op) when custody address has been removed', () => {
+    expect(set.addCustody(addCustody1).isOk()).toBe(true);
+    expect(set.addCustody(addCustody2).isOk()).toBe(true);
+    expect(set.merge(removeAllCustody2).isOk()).toBe(true);
+    expect(set.addCustody(addCustody1).isOk()).toBe(true);
+  });
 });
 
 describe('merge', () => {
-  // test('fails without custody address', () => {
-  //   expect(set.merge(addA).isOk()).toEqual(false);
-  //   expect(vAdds()).toEqual(new Set());
-  //   expect(vRems()).toEqual(new Set());
-  //   expect(eAddsHashes()).toEqual(new Set());
-  //   expect(eRems()).toEqual(new Map());
-  //   expect(messageHashes()).toEqual(new Set());
-  // });
-  // describe('with custody address', () => {
-  //   beforeEach(() => {
-  //     set.addCustody(custody1.signerKey);
-  //   });
-  //   describe('add', () => {
-  //     test('succeeds with a valid SignerAdd message', () => {
-  //       expect(set.merge(addA).isOk()).toEqual(true);
-  //       expect(vAdds()).toEqual(new Set([addA.data.body.childKey]));
-  //       expect(vRems()).toEqual(new Set());
-  //       expect(eAddsHashes()).toEqual(new Set([addA.hash]));
-  //       expect(eRems()).toEqual(new Map());
-  //       expect(messageHashes()).toEqual(new Set([addA.hash]));
-  //     });
-  //     test('succeeds with a duplicate valid SignerAdd message', () => {
-  //       expect(set.merge(addA).isOk()).toBe(true);
-  //       expect(set.merge(addA).isOk()).toBe(true);
-  //       expect(vAdds()).toEqual(new Set([addA.data.body.childKey]));
-  //       expect(vRems()).toEqual(new Set());
-  //       expect(eAddsHashes()).toEqual(new Set([addA.hash]));
-  //       expect(eRems()).toEqual(new Map());
-  //       expect(messageHashes()).toEqual(new Set([addA.hash]));
-  //     });
-  //     test('succeeds when adding a child to a parent', () => {
-  //       expect(set.merge(addA).isOk()).toBe(true);
-  //       expect(set.merge(addCToA).isOk()).toBe(true);
-  //       expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
-  //       expect(eAddsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-  //       expect(messageHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-  //     });
-  //     describe('when child already exists', () => {
-  //       describe('with different parent', () => {
-  //         beforeEach(() => {
-  //           expect(set.merge(addA).isOk()).toBe(true);
-  //           expect(set.merge(addB).isOk()).toBe(true);
-  //           expect(set.merge(addCToA).isOk()).toBe(true);
-  //           expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey, c.signerKey]));
-  //           expect(vRems()).toEqual(new Set());
-  //           expect(eAddsHashes()).toEqual(new Set([addA.hash, addB.hash, addCToA.hash]));
-  //           expect(eRemsHashes()).toEqual(new Set());
-  //         });
-  //         test('succeeds with a lower message hash but moves new edge to edgeRemoves', () => {
-  //           const addCToBLowerHash: SignerAdd = { ...addCToB, hash: addCToA.hash.slice(0, -1) };
-  //           expect(set.merge(addCToBLowerHash).isOk()).toBe(true);
-  //           expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey, c.signerKey]));
-  //           expect(vRems()).toEqual(new Set());
-  //           expect(eAddsHashes()).toEqual(new Set([addA.hash, addB.hash, addCToA.hash]));
-  //           expect(eRemsHashes()).toEqual(new Set([addCToBLowerHash.hash]));
-  //           expect(messageHashes()).toEqual(new Set([addA.hash, addB.hash, addCToA.hash, addCToBLowerHash.hash]));
-  //         });
-  //         test('succeeds with a higher message hash', () => {
-  //           const addCToBHigherHash: SignerAdd = { ...addCToB, hash: addCToA.hash + 'a' };
-  //           expect(set.merge(addCToBHigherHash).isOk()).toBe(true);
-  //           expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey, c.signerKey]));
-  //           expect(vRems()).toEqual(new Set());
-  //           expect(eAddsHashes()).toEqual(new Set([addA.hash, addB.hash, addCToBHigherHash.hash]));
-  //           expect(eRemsHashes()).toEqual(new Set([addCToA.hash]));
-  //           expect(messageHashes()).toEqual(new Set([addA.hash, addB.hash, addCToA.hash, addCToBHigherHash.hash]));
-  //         });
-  //       });
-  //       describe('with same parent', () => {
-  //         let addCToADuplicate: SignerAdd;
-  //         beforeAll(async () => {
-  //           addCToADuplicate = await Factories.SignerAdd.create({}, { transient: { signer: a, childSigner: c } });
-  //         });
-  //         beforeEach(() => {
-  //           expect(set.merge(addA).isOk()).toBe(true);
-  //           expect(set.merge(addCToA).isOk()).toBe(true);
-  //           expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
-  //           expect(vRems()).toEqual(new Set());
-  //           expect(eAddsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-  //           expect(eRemsHashes()).toEqual(new Set());
-  //         });
-  //         test('succeeds with a lower message hash but does not update edgeAdds', () => {
-  //           const addCToADuplicateLowerHash: SignerAdd = { ...addCToADuplicate, hash: addCToA.hash.slice(0, -1) };
-  //           expect(set.merge(addCToADuplicateLowerHash).isOk()).toBe(true);
-  //           expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
-  //           expect(vRems()).toEqual(new Set());
-  //           expect(eAddsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-  //           expect(eRemsHashes()).toEqual(new Set());
-  //           expect(messageHashes()).toEqual(new Set([addA.hash, addCToA.hash, addCToADuplicateLowerHash.hash]));
-  //         });
-  //         test('succeeds with a higher message hash', () => {
-  //           const addCToADuplicateHigherHash: SignerAdd = { ...addCToADuplicate, hash: addCToA.hash + 'z' };
-  //           expect(set.merge(addCToADuplicateHigherHash).isOk()).toBe(true);
-  //           expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
-  //           expect(vRems()).toEqual(new Set());
-  //           expect(eAddsHashes()).toEqual(new Set([addA.hash, addCToADuplicateHigherHash.hash]));
-  //           expect(eRemsHashes()).toEqual(new Set());
-  //           expect(messageHashes()).toEqual(new Set([addA.hash, addCToA.hash, addCToADuplicateHigherHash.hash]));
-  //         });
-  //       });
-  //     });
-  //     test('fails when parent does not exist', () => {
-  //       expect(vAdds().size).toEqual(0);
-  //       expect(set.merge(addCToA).isOk()).toBe(false);
-  //       expect(vAdds()).toEqual(new Set());
-  //       expect(vRems()).toEqual(new Set());
-  //       expect(eAddsHashes()).toEqual(new Set());
-  //       expect(eRemsHashes()).toEqual(new Set());
-  //       expect(messageHashes()).toEqual(new Set());
-  //     });
-  //     test('succeeds when child has already been deleted by another parent and moves new edge to edgeRemoves', () => {
-  //       const messages = [addA, addCToA, addB, remCFromA, addCToB];
-  //       for (const msg of messages) {
-  //         expect(set.merge(msg).isOk()).toBe(true);
-  //       }
-  //       expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey]));
-  //       expect(vRems()).toEqual(new Set([c.signerKey]));
-  //       expect(eAddsHashes()).toEqual(new Set([addA.hash, addB.hash]));
-  //       expect(eRemsHashes()).toEqual(new Set([addCToA.hash, addCToB.hash]));
-  //       expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-  //     });
-  //     describe('cycle prevention', () => {
-  //       let addCHigherHash: SignerAdd;
-  //       let addAToCHigherHash: SignerAdd;
-  //       beforeAll(async () => {
-  //         addCHigherHash = await Factories.SignerAdd.create({}, { transient: { signer: custody1, childSigner: c } });
-  //         addCHigherHash.hash = addCToA.hash + 'a';
-  //         addAToCHigherHash = await Factories.SignerAdd.create({}, { transient: { signer: c, childSigner: a } });
-  //         addAToCHigherHash.hash = addA.hash + 'a';
-  //       });
-  //       // When all messages are accepted, the set converges
-  //       afterEach(() => {
-  //         expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
-  //         expect(vRems()).toEqual(new Set());
-  //         expect(eAddsHashes()).toEqual(new Set([addAToCHigherHash.hash, addCHigherHash.hash]));
-  //         expect(eRemsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-  //         expect(messageHashes()).toEqual(
-  //           new Set([addA.hash, addCToA.hash, addAToCHigherHash.hash, addCHigherHash.hash])
-  //         );
-  //       });
-  //       test('succeeds after retry', () => {
-  //         expect(set.merge(addA).isOk()).toBe(true);
-  //         expect(set.merge(addCToA).isOk()).toBe(true);
-  //         expect(set.merge(addAToCHigherHash).isOk()).toBe(false);
-  //         expect(messageHashes()).not.toContain(addAToCHigherHash.hash);
-  //         expect(set.merge(addCHigherHash).isOk()).toBe(true);
-  //         expect(set.merge(addAToCHigherHash).isOk()).toBe(true); // Retry
-  //       });
-  //       test('succeeds when new edges do not create a cycle', () => {
-  //         expect(set.merge(addA).isOk()).toBe(true);
-  //         expect(set.merge(addCHigherHash).isOk()).toBe(true);
-  //         expect(set.merge(addCToA).isOk()).toBe(true);
-  //         expect(set.merge(addAToCHigherHash).isOk()).toBe(true);
-  //       });
-  //       test('succeeds when edge that would create a cycle has lower hash', () => {
-  //         expect(set.merge(addCHigherHash).isOk()).toBe(true);
-  //         expect(set.merge(addAToCHigherHash).isOk()).toBe(true);
-  //         expect(set.merge(addCToA).isOk()).toBe(true); // lower hash prevents cycle in edgeAdds
-  //         expect(set.merge(addA).isOk()).toBe(true);
-  //       });
-  //     });
-  //     test('succeeds when creating a cycle in edgeRemoves graph', async () => {
-  //       const addCToBHigherHash: SignerAdd = { ...addCToB, hash: addCToA.hash + 'a' };
-  //       const addAToCHigherHash = await Factories.SignerAdd.create({}, { transient: { signer: c, childSigner: a } });
-  //       addAToCHigherHash.hash = addA.hash + 'a';
-  //       const messages = [addA, addB, addCToA, addCToBHigherHash, addAToCHigherHash];
-  //       for (const msg of messages) {
-  //         expect(set.merge(msg).isOk()).toBe(true);
-  //       }
-  //       expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey, c.signerKey]));
-  //       expect(vRems()).toEqual(new Set());
-  //       expect(eAddsHashes()).toEqual(new Set([addB.hash, addAToCHigherHash.hash, addCToBHigherHash.hash]));
-  //       expect(eRemsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-  //       expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-  //     });
-  //     describe('when adding a child to subtree that is already removed', () => {
-  //       test('succeeds with new child', () => {
-  //         const messages = [addA, addCToA, remA, addDToC];
-  //         for (const msg of messages) {
-  //           expect(set.merge(msg).isOk()).toBe(true);
-  //         }
-  //         expect(vAdds()).toEqual(new Set());
-  //         expect(vRems()).toEqual(new Set([a.signerKey, c.signerKey, d.signerKey]));
-  //         expect(eAddsHashes()).toEqual(new Set());
-  //         expect(eRemsHashes()).toEqual(new Set([addA.hash, addCToA.hash, addDToC.hash]));
-  //         expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-  //       });
-  //       test('succeeds when child already exists in tree', () => {
-  //         const messages = [addB, addCToB, addA, remA, addCToA];
-  //         for (const msg of messages) {
-  //           expect(set.merge(msg).isOk()).toBe(true);
-  //         }
-  //         expect(vAdds()).toEqual(new Set([b.signerKey]));
-  //         expect(vRems()).toEqual(new Set([a.signerKey, c.signerKey]));
-  //         expect(eAddsHashes()).toEqual(new Set([addB.hash]));
-  //         expect(eRemsHashes()).toEqual(new Set([addCToB.hash, addA.hash, addCToA.hash]));
-  //         expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-  //       });
-  //     });
-  //     describe('when child is added by different parents and then deleted by both parents', () => {
-  //       afterEach(() => {
-  //         expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey]));
-  //         expect(vRems()).toEqual(new Set([c.signerKey]));
-  //         expect(eAddsHashes()).toEqual(new Set([addA.hash, addB.hash]));
-  //         expect(eRemsHashes()).toEqual(new Set([addCToA.hash, addCToB.hash]));
-  //       });
-  //       test('succeeds when edges are both added and then both removed', () => {
-  //         const messages = [addA, addB, addCToA, addCToB, remCFromA, remCFromB];
-  //         for (const msg of messages) {
-  //           expect(set.merge(msg).isOk()).toBe(true);
-  //         }
-  //         expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-  //       });
-  //       test('succeeds when edges are added and removed sequentially', () => {
-  //         const messages = [addA, addB, addCToA, remCFromA, addCToB, remCFromB];
-  //         for (const msg of messages) {
-  //           expect(set.merge(msg).isOk()).toBe(true);
-  //         }
-  //         expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-  //       });
-  //     });
-  //     test('succeeds when custody address has already been removed', () => {
-  //       expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
-  //       expect(set.merge(addA).isOk()).toBe(true);
-  //       expect(vAdds()).toEqual(new Set());
-  //       expect(vRems()).toEqual(new Set([a.signerKey]));
-  //       expect(eAddsHashes()).toEqual(new Set());
-  //       expect(eRemsHashes()).toEqual(new Set([addA.hash]));
-  //       expect(messageHashes()).toEqual(new Set([addA.hash]));
-  //     });
-  //   });
-  //   describe('remove', () => {
-  //     test('succeeds with a valid SignerRemove message', () => {
-  //       expect(set.merge(addA).isOk()).toBe(true);
-  //       expect(set.merge(remA).isOk()).toBe(true);
-  //       expect(vAdds()).toEqual(new Set());
-  //       expect(vRems()).toEqual(new Set([a.signerKey]));
-  //       expect(eAddsHashes()).toEqual(new Set());
-  //       expect(eRemsHashes()).toEqual(new Set([addA.hash]));
-  //       expect(messageHashes()).toEqual(new Set([addA.hash, remA.hash]));
-  //     });
-  //     test("fails when child hasn't been added yet", () => {
-  //       expect(set.merge(remA).isOk()).toBe(false);
-  //       expect(vAdds()).toEqual(new Set());
-  //       expect(vRems()).toEqual(new Set());
-  //       expect(eAddsHashes()).toEqual(new Set());
-  //       expect(eRemsHashes()).toEqual(new Set());
-  //       expect(messageHashes()).toEqual(new Set());
-  //     });
-  //     test('succeeds and removes subtree', async () => {
-  //       const e = await generateEd25519Signer();
-  //       const addEToC = await Factories.SignerAdd.create({}, { transient: { signer: c, childSigner: e } });
-  //       const messages = [addA, addB, addCToA, addDToC, addEToC, remA];
-  //       for (const msg of messages) {
-  //         expect(set.merge(msg).isOk()).toBe(true);
-  //       }
-  //       expect(vAdds()).toEqual(new Set([b.signerKey]));
-  //       expect(vRems()).toEqual(new Set([a.signerKey, c.signerKey, d.signerKey, e.signerKey]));
-  //       expect(eAddsHashes()).toEqual(new Set([addB.hash]));
-  //       expect(eRemsHashes()).toEqual(new Set([addA.hash, addCToA.hash, addDToC.hash, addEToC.hash]));
-  //       expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-  //     });
-  //     test("fails when child doesn't belong to parent", async () => {
-  //       expect(set.merge(addA).isOk()).toBe(true);
-  //       expect(set.merge(addCToA).isOk()).toBe(true);
-  //       const remC = await Factories.SignerRemove.create(
-  //         { data: { body: { childKey: c.signerKey } } },
-  //         { transient: { signer: custody1 } }
-  //       );
-  //       expect(set.merge(remC).isOk()).toBe(false);
-  //       expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
-  //       expect(vRems()).toEqual(new Set());
-  //       expect(eAddsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-  //       expect(eRemsHashes()).toEqual(new Set());
-  //       expect(messageHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-  //     });
-  //     test('succeeds when child belongs to parent', () => {
-  //       expect(set.merge(addA).isOk()).toBe(true);
-  //       expect(set.merge(addCToA).isOk()).toBe(true);
-  //       expect(set.merge(remCFromA).isOk()).toBe(true);
-  //       expect(vAdds()).toEqual(new Set([a.signerKey]));
-  //       expect(vRems()).toEqual(new Set([c.signerKey]));
-  //       expect(eAddsHashes()).toEqual(new Set([addA.hash]));
-  //       expect(eRemsHashes()).toEqual(new Set([addCToA.hash]));
-  //       expect(messageHashes()).toEqual(new Set([addA.hash, addCToA.hash, remCFromA.hash]));
-  //     });
-  //     test('succeeds with duplicate signer remove message', () => {
-  //       expect(set.merge(addA).isOk()).toBe(true);
-  //       expect(set.merge(remA).isOk()).toBe(true);
-  //       expect(set.merge(remA).isOk()).toBe(true);
-  //       expect(vAdds()).toEqual(new Set());
-  //       expect(vRems()).toEqual(new Set([a.signerKey]));
-  //       expect(eAddsHashes()).toEqual(new Set());
-  //       expect(eRemsHashes()).toEqual(new Set([addA.hash]));
-  //       expect(messageHashes()).toEqual(new Set([addA.hash, remA.hash]));
-  //     });
-  //     test('a child is removed after its parent has already been removed', () => {
-  //       const messages = [addA, addCToA, remA, remCFromA];
-  //       for (const msg of messages) {
-  //         expect(set.merge(msg).isOk()).toBe(true);
-  //       }
-  //       expect(vAdds()).toEqual(new Set());
-  //       expect(vRems()).toEqual(new Set([a.signerKey, c.signerKey]));
-  //       expect(eAddsHashes()).toEqual(new Set());
-  //       expect(eRemsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-  //       expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-  //     });
-  //     test('succeeds when custody address has already been removed', () => {
-  //       expect(set.merge(addA).isOk()).toBe(true);
-  //       expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
-  //       expect(set.merge(remA).isOk()).toBe(true);
-  //       expect(vAdds()).toEqual(new Set());
-  //       expect(vRems()).toEqual(new Set([a.signerKey]));
-  //       expect(eAddsHashes()).toEqual(new Set());
-  //       expect(eRemsHashes()).toEqual(new Set([addA.hash]));
-  //       expect(messageHashes()).toEqual(new Set([addA.hash, remA.hash]));
-  //     });
-  //   });
-  // });
+  test('fails without custody address', () => {
+    const res = set.merge(addA);
+    expect(res.isOk()).toBe(false);
+    expect(res._unsafeUnwrapErr()).toBe('SignerSet.mergeSignerAdd: custodyAddress does not exist');
+    expect(custodyAdds()).toEqual(new Map());
+    expect(custodyRems()).toEqual(new Map());
+    expect(signerAdds()).toEqual(new Map());
+    expect(signerRems()).toEqual(new Map());
+  });
+
+  test('succeeds (no-ops) when custody address has been removed', () => {
+    expect(set.addCustody(addCustody1).isOk()).toBe(true);
+    expect(set.addCustody(addCustody2).isOk()).toBe(true);
+    expect(set.merge(removeAllCustody2).isOk()).toBe(true);
+    expect(set.merge(addA).isOk()).toBe(true);
+    expect(custodyAdds()).toEqual(new Map([[custody2.signerKey, addCustody2]]));
+    expect(custodyRems()).toEqual(new Map([[custody1.signerKey, removeAllCustody2]]));
+    expect(signerAdds()).toEqual(new Map());
+    expect(signerRems()).toEqual(new Map());
+  });
+
+  describe('with custody address', () => {
+    beforeEach(() => {
+      set.addCustody(addCustody1);
+      expect(custodyAdds()).toEqual(new Map([[custody1.signerKey, addCustody1]]));
+    });
+
+    describe('mergeCustodyRemoveAll', () => {
+      test('succeeds when there are no previous custody addresses', () => {
+        expect(set.merge(removeAllCustody1).isOk()).toBe(true);
+        expect(custodyAdds()).toEqual(new Map([[custody1.signerKey, addCustody1]]));
+        expect(custodyRems()).toEqual(new Map());
+        expect(signerAdds()).toEqual(new Map());
+        expect(signerRems()).toEqual(new Map());
+      });
+
+      test('succeeds and removes previous custody addresses', () => {
+        expect(set.addCustody(addCustody2).isOk()).toBe(true);
+        expect(set.merge(removeAllCustody2).isOk()).toBe(true);
+        expect(custodyAdds()).toEqual(new Map([[custody2.signerKey, addCustody2]]));
+        expect(custodyRems()).toEqual(new Map([[custody1.signerKey, removeAllCustody2]]));
+        expect(signerAdds()).toEqual(new Map());
+        expect(signerRems()).toEqual(new Map());
+      });
+
+      test('succeeds and does not remove more recent custody addresses', () => {
+        expect(set.addCustody(addCustody2).isOk()).toBe(true);
+        expect(set.merge(removeAllCustody1).isOk()).toBe(true);
+        expect(custodyAdds()).toEqual(
+          new Map([
+            [custody2.signerKey, addCustody2],
+            [custody1.signerKey, addCustody1],
+          ])
+        );
+        expect(custodyRems()).toEqual(new Map());
+        expect(signerAdds()).toEqual(new Map());
+        expect(signerRems()).toEqual(new Map());
+      });
+
+      test('fails when custody address signer has not been added', () => {
+        const res = set.merge(removeAllCustody2);
+        expect(res.isOk()).toBe(false);
+        expect(res._unsafeUnwrapErr()).toBe('SignerSet.mergeCustodyRemoveAll: custodyAddress does not exist');
+        expect(custodyAdds()).toEqual(new Map([[custody1.signerKey, addCustody1]]));
+        expect(custodyRems()).toEqual(new Map());
+        expect(signerAdds()).toEqual(new Map());
+        expect(signerRems()).toEqual(new Map());
+      });
+    });
+
+    describe('mergeSignerAdd', () => {
+      test('succeeds with a valid SignerAdd message', () => {
+        expect(set.merge(addA).isOk()).toEqual(true);
+        expect(custodyAdds()).toEqual(new Map([[custody1.signerKey, addCustody1]]));
+        expect(custodyRems()).toEqual(new Map());
+        expect(signerAdds()).toEqual(new Map([[a.signerKey, addA]]));
+        expect(signerRems()).toEqual(new Map());
+      });
+
+      test('succeeds with a duplicate valid SignerAdd message', () => {
+        expect(set.merge(addA).isOk()).toBe(true);
+        expect(set.merge(addA).isOk()).toBe(true);
+        expect(custodyAdds()).toEqual(new Map([[custody1.signerKey, addCustody1]]));
+        expect(custodyRems()).toEqual(new Map());
+        expect(signerAdds()).toEqual(new Map([[a.signerKey, addA]]));
+        expect(signerRems()).toEqual(new Map());
+      });
+
+      test('fails when trying to add a signer to another delegate', () => {
+        expect(set.merge(addA).isOk()).toBe(true);
+        const res = set.merge(addCToA);
+        expect(res.isOk()).toBe(false);
+        expect(res._unsafeUnwrapErr()).toBe('SignerSet.mergeSignerAdd: custodyAddress does not exist');
+        expect(custodyAdds()).toEqual(new Map([[custody1.signerKey, addCustody1]]));
+        expect(custodyRems()).toEqual(new Map());
+        expect(signerAdds()).toEqual(new Map([[a.signerKey, addA]]));
+        expect(signerRems()).toEqual(new Map());
+      });
+
+      describe('when signer already exists from different custody address', () => {
+        beforeEach(() => {
+          expect(set.addCustody(addCustody2).isOk()).toBe(true);
+        });
+
+        test('succeeds with later custody address', () => {
+          expect(set.merge(addA).isOk()).toBe(true);
+          expect(set.merge(addA2).isOk()).toBe(true);
+          expect(custodyAdds()).toEqual(
+            new Map([
+              [custody1.signerKey, addCustody1],
+              [custody2.signerKey, addCustody2],
+            ])
+          );
+          expect(custodyRems()).toEqual(new Map());
+          expect(signerAdds()).toEqual(new Map([[a.signerKey, addA2]]));
+          expect(signerRems()).toEqual(new Map());
+        });
+
+        test('succeeds (no-op) with earlier custody address', () => {
+          expect(set.merge(addA2).isOk()).toBe(true);
+          expect(set.merge(addA).isOk()).toBe(true);
+          expect(custodyAdds()).toEqual(
+            new Map([
+              [custody1.signerKey, addCustody1],
+              [custody2.signerKey, addCustody2],
+            ])
+          );
+          expect(custodyRems()).toEqual(new Map());
+          expect(signerAdds()).toEqual(new Map([[a.signerKey, addA2]]));
+          expect(signerRems()).toEqual(new Map());
+        });
+
+        test('succeeds with custody addresses from same block', () => {
+          // TODO
+        });
+      });
+
+      describe('when signer already exists from the same custody address', () => {
+        beforeEach(() => {
+          expect(set.merge(addA).isOk()).toBe(true);
+        });
+
+        test('succeeds with higher message hash', () => {
+          const addAHigherHash: SignerAdd = { ...addA, hash: addA.hash + 'a' };
+          expect(set.merge(addAHigherHash).isOk()).toBe(true);
+          expect(custodyAdds()).toEqual(new Map([[custody1.signerKey, addCustody1]]));
+          expect(custodyRems()).toEqual(new Map());
+          expect(signerAdds()).toEqual(new Map([[a.signerKey, addAHigherHash]]));
+          expect(signerRems()).toEqual(new Map());
+        });
+
+        test('succeeds (no-ops) with lower message hash', () => {
+          const addALowerHash: SignerAdd = { ...addA, hash: addA.hash.slice(0, -1) };
+          expect(set.merge(addALowerHash).isOk()).toBe(true);
+          expect(custodyAdds()).toEqual(new Map([[custody1.signerKey, addCustody1]]));
+          expect(custodyRems()).toEqual(new Map());
+          expect(signerAdds()).toEqual(new Map([[a.signerKey, addA]]));
+          expect(signerRems()).toEqual(new Map());
+        });
+      });
+
+      describe('when signer has been removed', () => {
+        beforeEach(() => {
+          expect(set.addCustody(addCustody2).isOk()).toBe(true);
+        });
+
+        test('succeeds with later custody address', () => {
+          expect(set.merge(remA).isOk()).toBe(true);
+          expect(set.merge(addA2).isOk()).toBe(true);
+          expect(custodyAdds()).toEqual(
+            new Map([
+              [custody1.signerKey, addCustody1],
+              [custody2.signerKey, addCustody2],
+            ])
+          );
+          expect(custodyRems()).toEqual(new Map());
+          expect(signerAdds()).toEqual(new Map([[a.signerKey, addA2]]));
+          expect(signerRems()).toEqual(new Map());
+        });
+
+        test('succeeds (no-ops) with earlier custody address', () => {
+          expect(set.merge(remA2).isOk()).toBe(true);
+          expect(set.merge(addA).isOk()).toBe(true);
+          expect(custodyAdds()).toEqual(
+            new Map([
+              [custody1.signerKey, addCustody1],
+              [custody2.signerKey, addCustody2],
+            ])
+          );
+          expect(custodyRems()).toEqual(new Map());
+          expect(signerAdds()).toEqual(new Map());
+          expect(signerRems()).toEqual(new Map([[a.signerKey, remA2]]));
+        });
+      });
+
+      describe('when signer is added and removed by two custody addresses', () => {
+        beforeEach(() => {
+          expect(set.addCustody(addCustody2).isOk()).toBe(true);
+        });
+
+        afterEach(() => {
+          expect(custodyAdds()).toEqual(
+            new Map([
+              [custody1.signerKey, addCustody1],
+              [custody2.signerKey, addCustody2],
+            ])
+          );
+          expect(custodyRems()).toEqual(new Map());
+          expect(signerAdds()).toEqual(new Map());
+          expect(signerRems()).toEqual(new Map([[a.signerKey, remA2]]));
+        });
+
+        test('succeeds when adds are received first', () => {
+          for (const msg of [addA, addA2, remA, remA2]) {
+            expect(set.merge(msg).isOk()).toBe(true);
+          }
+        });
+
+        test('succeeds when removes are received first', () => {
+          for (const msg of [remA, remA2, addA, addA2]) {
+            expect(set.merge(msg).isOk()).toBe(true);
+          }
+        });
+
+        test('succeeds when messages are ordered by custody address', () => {
+          for (const msg of [addA, remA, addA2, remA2]) {
+            expect(set.merge(msg).isOk()).toBe(true);
+          }
+        });
+      });
+    });
+
+    describe('mergeSignerRemove', () => {
+      test('succeeds with a valid SignerRemove message', () => {
+        expect(set.merge(addA).isOk()).toBe(true);
+        expect(set.merge(remA).isOk()).toBe(true);
+        expect(custodyAdds()).toEqual(new Map([[custody1.signerKey, addCustody1]]));
+        expect(custodyRems()).toEqual(new Map());
+        expect(signerAdds()).toEqual(new Map());
+        expect(signerRems()).toEqual(new Map([[a.signerKey, remA]]));
+      });
+
+      test('succeeds when signer has not been added', () => {
+        expect(set.merge(remA).isOk()).toBe(true);
+        expect(custodyAdds()).toEqual(new Map([[custody1.signerKey, addCustody1]]));
+        expect(custodyRems()).toEqual(new Map());
+        expect(signerAdds()).toEqual(new Map());
+        expect(signerRems()).toEqual(new Map([[a.signerKey, remA]]));
+      });
+
+      test('succeeds with duplicate signer remove message', () => {
+        expect(set.merge(remA).isOk()).toBe(true);
+        expect(set.merge(remA).isOk()).toBe(true);
+        expect(custodyAdds()).toEqual(new Map([[custody1.signerKey, addCustody1]]));
+        expect(custodyRems()).toEqual(new Map());
+        expect(signerAdds()).toEqual(new Map());
+        expect(signerRems()).toEqual(new Map([[a.signerKey, remA]]));
+      });
+
+      test('fails when signer is the delegate', () => {
+        expect(set.merge(addA).isOk()).toBe(true);
+        const res = set.merge(remAFromA);
+        expect(res.isOk()).toBe(false);
+        expect(res._unsafeUnwrapErr()).toBe('SignerSet.mergeSignerRemove: custodyAddress does not exist');
+      });
+
+      test('fails when signer is another delegate', () => {
+        expect(set.merge(addA).isOk()).toBe(true);
+        expect(set.merge(addB).isOk()).toBe(true);
+        const res = set.merge(remBFromA);
+        expect(res.isOk()).toBe(false);
+        expect(res._unsafeUnwrapErr()).toBe('SignerSet.mergeSignerRemove: custodyAddress does not exist');
+      });
+    });
+  });
 });

--- a/src/sets/signerSet.test.ts
+++ b/src/sets/signerSet.test.ts
@@ -1,23 +1,21 @@
-import { SignerAdd, SignerRemove, EthereumSigner, Ed25519Signer } from '~/types';
+import { SignerAdd, SignerRemove, EthereumSigner, Ed25519Signer, CustodyAddEvent, CustodyRemoveAll } from '~/types';
 import SignerSet from '~/sets/signerSet';
 import { Factories } from '~/factories';
 import { generateEd25519Signer, generateEthereumSigner } from '~/utils';
 
 const set = new SignerSet();
-const vAdds = () => set._getVertexAdds();
-const vRems = () => set._getVertexRemoves();
-const eAdds = () => set._getEdgeAdds();
-const eAddsHashes = () => new Set([...eAdds().values()]);
-const eRems = () => set._getEdgeRemoves();
-const eRemsHashes = () => new Set([...eRems().values()]);
-const cAdds = () => set._getCustodyAdds();
-const cRems = () => set._getCustodyRemoves();
-const custodyAddresses = () => set._getCustodyAddresses();
-const messages = () => set._getMessages();
-const messageHashes = () => new Set([...messages().keys()]);
+const custodyAdds = () => set._getCustodyAdds();
+const custodyAddsKeys = () => new Set([...set._getCustodyAdds().keys()]);
+const custodyRems = () => set._getCustodyRemoves();
+const signerAdds = () => set._getSignerAdds();
+const signerRems = () => set._getSignerRemoves();
 
 let custody1: EthereumSigner;
+let addCustody1: CustodyAddEvent;
+let removeCustody1: CustodyRemoveAll;
 let custody2: EthereumSigner;
+let addCustody2: CustodyAddEvent;
+let removeCustody2: CustodyRemoveAll;
 let a: Ed25519Signer;
 let addA: SignerAdd;
 let remA: SignerRemove;
@@ -25,15 +23,12 @@ let b: Ed25519Signer;
 let addB: SignerAdd;
 let c: Ed25519Signer;
 let addCToA: SignerAdd;
-let addCToB: SignerAdd;
-let remCFromA: SignerRemove;
-let remCFromB: SignerRemove;
-let d: Ed25519Signer;
-let addDToC: SignerAdd;
 
 beforeAll(async () => {
   custody1 = await generateEthereumSigner();
+  addCustody1 = await Factories.CustodyAddEvent.create({}, { transient: { signer: custody1 } });
   custody2 = await generateEthereumSigner();
+  addCustody2 = await Factories.CustodyAddEvent.create({}, { transient: { signer: custody2 } });
   a = await generateEd25519Signer();
   addA = await Factories.SignerAdd.create({}, { transient: { signer: custody1, childSigner: a } });
   remA = await Factories.SignerRemove.create(
@@ -44,17 +39,6 @@ beforeAll(async () => {
   addB = await Factories.SignerAdd.create({}, { transient: { signer: custody1, childSigner: b } });
   c = await generateEd25519Signer();
   addCToA = await Factories.SignerAdd.create({}, { transient: { signer: a, childSigner: c } });
-  addCToB = await Factories.SignerAdd.create({}, { transient: { signer: b, childSigner: c } });
-  remCFromA = await Factories.SignerRemove.create(
-    { data: { body: { childKey: c.signerKey } } },
-    { transient: { signer: a } }
-  );
-  remCFromB = await Factories.SignerRemove.create(
-    { data: { body: { childKey: c.signerKey } } },
-    { transient: { signer: b } }
-  );
-  d = await generateEd25519Signer();
-  addDToC = await Factories.SignerAdd.create({}, { transient: { signer: c, childSigner: d } });
 });
 
 beforeEach(() => {
@@ -63,449 +47,411 @@ beforeEach(() => {
 
 describe('addCustody', () => {
   test('succeeds with new custody address', () => {
-    expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
-    expect(custodyAddresses()).toContain(custody1.signerKey);
-    expect(vAdds()).toEqual(new Set());
-    expect(messageHashes()).toEqual(new Set());
+    expect(set.addCustody(addCustody1).isOk()).toBe(true);
+    expect(custodyAdds()).toEqual(new Map([[custody1.signerKey, addCustody1]]));
+    expect(custodyRems()).toEqual(new Map());
   });
 
   test('succeeds with multiple new custody addresses', () => {
-    expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
-    expect(set.addCustody(custody2.signerKey).isOk()).toBe(true);
-    expect(custodyAddresses()).toEqual(new Set([custody1.signerKey, custody2.signerKey]));
-    expect(vAdds()).toEqual(new Set());
-    expect(messageHashes()).toEqual(new Set());
+    expect(set.addCustody(addCustody1).isOk()).toBe(true);
+    expect(set.addCustody(addCustody2).isOk()).toBe(true);
+    expect(custodyAdds()).toEqual(
+      new Map([
+        [custody1.signerKey, addCustody1],
+        [custody2.signerKey, addCustody2],
+      ])
+    );
+    expect(custodyRems()).toEqual(new Map());
   });
 
-  test('succeeds with a duplicate custody address (idempotent)', () => {
-    expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
-    expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
-    expect(custodyAddresses()).toEqual(new Set([custody1.signerKey]));
-    expect(vAdds()).toEqual(new Set());
-    expect(messageHashes()).toEqual(new Set());
-  });
-
-  test('fails when custody address is already a delegate', () => {
-    expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
-    expect(set.merge(addA).isOk()).toBe(true);
-    const res = set.addCustody(a.signerKey);
-    expect(res.isOk()).toBe(false);
-    expect(res._unsafeUnwrapErr()).toBe('SignerSet.addCustody: custodyAddress already exists as a delegate');
-    expect(custodyAddresses()).toEqual(new Set([custody1.signerKey]));
-    expect(vAdds()).toEqual(new Set([a.signerKey]));
-    expect(messageHashes()).toEqual(new Set([addA.hash]));
-  });
-
-  test('fails when custody address has already been removed', () => {
-    expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
-    expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
-    const res = set.addCustody(custody1.signerKey);
-    expect(res.isOk()).toBe(false);
-    expect(res._unsafeUnwrapErr()).toBe('SignerSet.addCustody: custodyAddress has been removed');
-  });
+  // test('succeeds with a duplicate custody address (idempotent)', () => {
+  //   expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
+  //   expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
+  //   expect(custodyAddresses()).toEqual(new Set([custody1.signerKey]));
+  //   expect(vAdds()).toEqual(new Set());
+  //   expect(messageHashes()).toEqual(new Set());
+  // });
+  // test('fails when custody address is already a delegate', () => {
+  //   expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
+  //   expect(set.merge(addA).isOk()).toBe(true);
+  //   const res = set.addCustody(a.signerKey);
+  //   expect(res.isOk()).toBe(false);
+  //   expect(res._unsafeUnwrapErr()).toBe('SignerSet.addCustody: custodyAddress already exists as a delegate');
+  //   expect(custodyAddresses()).toEqual(new Set([custody1.signerKey]));
+  //   expect(vAdds()).toEqual(new Set([a.signerKey]));
+  //   expect(messageHashes()).toEqual(new Set([addA.hash]));
+  // });
+  // test('fails when custody address has already been removed', () => {
+  //   expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
+  //   expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
+  //   const res = set.addCustody(custody1.signerKey);
+  //   expect(res.isOk()).toBe(false);
+  //   expect(res._unsafeUnwrapErr()).toBe('SignerSet.addCustody: custodyAddress has been removed');
+  // });
 });
 
 describe('removeCustody', () => {
-  test('fails when custody address does not exist', () => {
-    const res = set.removeCustody(custody1.signerKey);
-    expect(res.isOk()).toBe(false);
-    expect(res._unsafeUnwrapErr()).toBe('SignerSet.removeCustody: custodyAddress does not exist');
-  });
-
-  describe('with custody address', () => {
-    beforeEach(() => {
-      expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
-      expect(cAdds()).toEqual(new Set([custody1.signerKey]));
-      expect(cRems()).toEqual(new Set());
-    });
-
-    test('succeeds', () => {
-      expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
-      expect(cAdds()).toEqual(new Set());
-      expect(cRems()).toEqual(new Set([custody1.signerKey]));
-    });
-
-    test('succeeds and removes delegates', () => {
-      expect(set.merge(addA).isOk()).toBe(true);
-      expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
-      expect(cAdds()).toEqual(new Set());
-      expect(cRems()).toEqual(new Set([custody1.signerKey]));
-      expect(vAdds()).toEqual(new Set());
-      expect(vRems()).toEqual(new Set([a.signerKey]));
-      expect(eAddsHashes()).toEqual(new Set());
-      expect(eRemsHashes()).toEqual(new Set([addA.hash]));
-      expect(messageHashes()).toEqual(new Set([addA.hash]));
-    });
-
-    test('succeeds and removes delegates and subtrees', () => {
-      const messages = [addA, addB, addCToA];
-      for (const msg of messages) {
-        expect(set.merge(msg).isOk()).toBe(true);
-      }
-      expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
-      expect(cAdds()).toEqual(new Set());
-      expect(cRems()).toEqual(new Set([custody1.signerKey]));
-      expect(vAdds()).toEqual(new Set());
-      expect(vRems()).toEqual(new Set([a.signerKey, b.signerKey, c.signerKey]));
-      expect(eAddsHashes()).toEqual(new Set());
-      expect(eRemsHashes()).toEqual(new Set([addA.hash, addB.hash, addCToA.hash]));
-      expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-    });
-  });
+  // test('fails when custody address does not exist', () => {
+  //   const res = set.removeCustody(custody1.signerKey);
+  //   expect(res.isOk()).toBe(false);
+  //   expect(res._unsafeUnwrapErr()).toBe('SignerSet.removeCustody: custodyAddress does not exist');
+  // });
+  // describe('with custody address', () => {
+  //   beforeEach(() => {
+  //     expect(set.addCustody(custody1.signerKey).isOk()).toBe(true);
+  //     expect(cAdds()).toEqual(new Set([custody1.signerKey]));
+  //     expect(cRems()).toEqual(new Set());
+  //   });
+  //   test('succeeds', () => {
+  //     expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
+  //     expect(cAdds()).toEqual(new Set());
+  //     expect(cRems()).toEqual(new Set([custody1.signerKey]));
+  //   });
+  //   test('succeeds and removes delegates', () => {
+  //     expect(set.merge(addA).isOk()).toBe(true);
+  //     expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
+  //     expect(cAdds()).toEqual(new Set());
+  //     expect(cRems()).toEqual(new Set([custody1.signerKey]));
+  //     expect(vAdds()).toEqual(new Set());
+  //     expect(vRems()).toEqual(new Set([a.signerKey]));
+  //     expect(eAddsHashes()).toEqual(new Set());
+  //     expect(eRemsHashes()).toEqual(new Set([addA.hash]));
+  //     expect(messageHashes()).toEqual(new Set([addA.hash]));
+  //   });
+  //   test('succeeds and removes delegates and subtrees', () => {
+  //     const messages = [addA, addB, addCToA];
+  //     for (const msg of messages) {
+  //       expect(set.merge(msg).isOk()).toBe(true);
+  //     }
+  //     expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
+  //     expect(cAdds()).toEqual(new Set());
+  //     expect(cRems()).toEqual(new Set([custody1.signerKey]));
+  //     expect(vAdds()).toEqual(new Set());
+  //     expect(vRems()).toEqual(new Set([a.signerKey, b.signerKey, c.signerKey]));
+  //     expect(eAddsHashes()).toEqual(new Set());
+  //     expect(eRemsHashes()).toEqual(new Set([addA.hash, addB.hash, addCToA.hash]));
+  //     expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
+  //   });
+  // });
 });
 
 describe('merge', () => {
-  test('fails without custody address', () => {
-    expect(set.merge(addA).isOk()).toEqual(false);
-    expect(vAdds()).toEqual(new Set());
-    expect(vRems()).toEqual(new Set());
-    expect(eAddsHashes()).toEqual(new Set());
-    expect(eRems()).toEqual(new Map());
-    expect(messageHashes()).toEqual(new Set());
-  });
-
-  describe('with custody address', () => {
-    beforeEach(() => {
-      set.addCustody(custody1.signerKey);
-    });
-
-    describe('add', () => {
-      test('succeeds with a valid SignerAdd message', () => {
-        expect(set.merge(addA).isOk()).toEqual(true);
-        expect(vAdds()).toEqual(new Set([addA.data.body.childKey]));
-        expect(vRems()).toEqual(new Set());
-        expect(eAddsHashes()).toEqual(new Set([addA.hash]));
-        expect(eRems()).toEqual(new Map());
-        expect(messageHashes()).toEqual(new Set([addA.hash]));
-      });
-
-      test('succeeds with a duplicate valid SignerAdd message', () => {
-        expect(set.merge(addA).isOk()).toBe(true);
-        expect(set.merge(addA).isOk()).toBe(true);
-        expect(vAdds()).toEqual(new Set([addA.data.body.childKey]));
-        expect(vRems()).toEqual(new Set());
-        expect(eAddsHashes()).toEqual(new Set([addA.hash]));
-        expect(eRems()).toEqual(new Map());
-        expect(messageHashes()).toEqual(new Set([addA.hash]));
-      });
-
-      test('succeeds when adding a child to a parent', () => {
-        expect(set.merge(addA).isOk()).toBe(true);
-        expect(set.merge(addCToA).isOk()).toBe(true);
-        expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
-        expect(eAddsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-        expect(messageHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-      });
-
-      describe('when child already exists', () => {
-        describe('with different parent', () => {
-          beforeEach(() => {
-            expect(set.merge(addA).isOk()).toBe(true);
-            expect(set.merge(addB).isOk()).toBe(true);
-            expect(set.merge(addCToA).isOk()).toBe(true);
-            expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey, c.signerKey]));
-            expect(vRems()).toEqual(new Set());
-            expect(eAddsHashes()).toEqual(new Set([addA.hash, addB.hash, addCToA.hash]));
-            expect(eRemsHashes()).toEqual(new Set());
-          });
-
-          test('succeeds with a lower message hash but moves new edge to edgeRemoves', () => {
-            const addCToBLowerHash: SignerAdd = { ...addCToB, hash: addCToA.hash.slice(0, -1) };
-            expect(set.merge(addCToBLowerHash).isOk()).toBe(true);
-            expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey, c.signerKey]));
-            expect(vRems()).toEqual(new Set());
-            expect(eAddsHashes()).toEqual(new Set([addA.hash, addB.hash, addCToA.hash]));
-            expect(eRemsHashes()).toEqual(new Set([addCToBLowerHash.hash]));
-            expect(messageHashes()).toEqual(new Set([addA.hash, addB.hash, addCToA.hash, addCToBLowerHash.hash]));
-          });
-
-          test('succeeds with a higher message hash', () => {
-            const addCToBHigherHash: SignerAdd = { ...addCToB, hash: addCToA.hash + 'a' };
-            expect(set.merge(addCToBHigherHash).isOk()).toBe(true);
-            expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey, c.signerKey]));
-            expect(vRems()).toEqual(new Set());
-            expect(eAddsHashes()).toEqual(new Set([addA.hash, addB.hash, addCToBHigherHash.hash]));
-            expect(eRemsHashes()).toEqual(new Set([addCToA.hash]));
-            expect(messageHashes()).toEqual(new Set([addA.hash, addB.hash, addCToA.hash, addCToBHigherHash.hash]));
-          });
-        });
-
-        describe('with same parent', () => {
-          let addCToADuplicate: SignerAdd;
-
-          beforeAll(async () => {
-            addCToADuplicate = await Factories.SignerAdd.create({}, { transient: { signer: a, childSigner: c } });
-          });
-
-          beforeEach(() => {
-            expect(set.merge(addA).isOk()).toBe(true);
-            expect(set.merge(addCToA).isOk()).toBe(true);
-            expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
-            expect(vRems()).toEqual(new Set());
-            expect(eAddsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-            expect(eRemsHashes()).toEqual(new Set());
-          });
-
-          test('succeeds with a lower message hash but does not update edgeAdds', () => {
-            const addCToADuplicateLowerHash: SignerAdd = { ...addCToADuplicate, hash: addCToA.hash.slice(0, -1) };
-            expect(set.merge(addCToADuplicateLowerHash).isOk()).toBe(true);
-            expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
-            expect(vRems()).toEqual(new Set());
-            expect(eAddsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-            expect(eRemsHashes()).toEqual(new Set());
-            expect(messageHashes()).toEqual(new Set([addA.hash, addCToA.hash, addCToADuplicateLowerHash.hash]));
-          });
-
-          test('succeeds with a higher message hash', () => {
-            const addCToADuplicateHigherHash: SignerAdd = { ...addCToADuplicate, hash: addCToA.hash + 'z' };
-            expect(set.merge(addCToADuplicateHigherHash).isOk()).toBe(true);
-            expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
-            expect(vRems()).toEqual(new Set());
-            expect(eAddsHashes()).toEqual(new Set([addA.hash, addCToADuplicateHigherHash.hash]));
-            expect(eRemsHashes()).toEqual(new Set());
-            expect(messageHashes()).toEqual(new Set([addA.hash, addCToA.hash, addCToADuplicateHigherHash.hash]));
-          });
-        });
-      });
-
-      test('fails when parent does not exist', () => {
-        expect(vAdds().size).toEqual(0);
-        expect(set.merge(addCToA).isOk()).toBe(false);
-        expect(vAdds()).toEqual(new Set());
-        expect(vRems()).toEqual(new Set());
-        expect(eAddsHashes()).toEqual(new Set());
-        expect(eRemsHashes()).toEqual(new Set());
-        expect(messageHashes()).toEqual(new Set());
-      });
-
-      test('succeeds when child has already been deleted by another parent and moves new edge to edgeRemoves', () => {
-        const messages = [addA, addCToA, addB, remCFromA, addCToB];
-        for (const msg of messages) {
-          expect(set.merge(msg).isOk()).toBe(true);
-        }
-        expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey]));
-        expect(vRems()).toEqual(new Set([c.signerKey]));
-        expect(eAddsHashes()).toEqual(new Set([addA.hash, addB.hash]));
-        expect(eRemsHashes()).toEqual(new Set([addCToA.hash, addCToB.hash]));
-        expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-      });
-
-      describe('cycle prevention', () => {
-        let addCHigherHash: SignerAdd;
-        let addAToCHigherHash: SignerAdd;
-
-        beforeAll(async () => {
-          addCHigherHash = await Factories.SignerAdd.create({}, { transient: { signer: custody1, childSigner: c } });
-          addCHigherHash.hash = addCToA.hash + 'a';
-          addAToCHigherHash = await Factories.SignerAdd.create({}, { transient: { signer: c, childSigner: a } });
-          addAToCHigherHash.hash = addA.hash + 'a';
-        });
-
-        // When all messages are accepted, the set converges
-        afterEach(() => {
-          expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
-          expect(vRems()).toEqual(new Set());
-          expect(eAddsHashes()).toEqual(new Set([addAToCHigherHash.hash, addCHigherHash.hash]));
-          expect(eRemsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-          expect(messageHashes()).toEqual(
-            new Set([addA.hash, addCToA.hash, addAToCHigherHash.hash, addCHigherHash.hash])
-          );
-        });
-
-        test('succeeds after retry', () => {
-          expect(set.merge(addA).isOk()).toBe(true);
-          expect(set.merge(addCToA).isOk()).toBe(true);
-          expect(set.merge(addAToCHigherHash).isOk()).toBe(false);
-          expect(messageHashes()).not.toContain(addAToCHigherHash.hash);
-          expect(set.merge(addCHigherHash).isOk()).toBe(true);
-          expect(set.merge(addAToCHigherHash).isOk()).toBe(true); // Retry
-        });
-
-        test('succeeds when new edges do not create a cycle', () => {
-          expect(set.merge(addA).isOk()).toBe(true);
-          expect(set.merge(addCHigherHash).isOk()).toBe(true);
-          expect(set.merge(addCToA).isOk()).toBe(true);
-          expect(set.merge(addAToCHigherHash).isOk()).toBe(true);
-        });
-
-        test('succeeds when edge that would create a cycle has lower hash', () => {
-          expect(set.merge(addCHigherHash).isOk()).toBe(true);
-          expect(set.merge(addAToCHigherHash).isOk()).toBe(true);
-          expect(set.merge(addCToA).isOk()).toBe(true); // lower hash prevents cycle in edgeAdds
-          expect(set.merge(addA).isOk()).toBe(true);
-        });
-      });
-
-      test('succeeds when creating a cycle in edgeRemoves graph', async () => {
-        const addCToBHigherHash: SignerAdd = { ...addCToB, hash: addCToA.hash + 'a' };
-        const addAToCHigherHash = await Factories.SignerAdd.create({}, { transient: { signer: c, childSigner: a } });
-        addAToCHigherHash.hash = addA.hash + 'a';
-        const messages = [addA, addB, addCToA, addCToBHigherHash, addAToCHigherHash];
-        for (const msg of messages) {
-          expect(set.merge(msg).isOk()).toBe(true);
-        }
-        expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey, c.signerKey]));
-        expect(vRems()).toEqual(new Set());
-        expect(eAddsHashes()).toEqual(new Set([addB.hash, addAToCHigherHash.hash, addCToBHigherHash.hash]));
-        expect(eRemsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-        expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-      });
-
-      describe('when adding a child to subtree that is already removed', () => {
-        test('succeeds with new child', () => {
-          const messages = [addA, addCToA, remA, addDToC];
-          for (const msg of messages) {
-            expect(set.merge(msg).isOk()).toBe(true);
-          }
-          expect(vAdds()).toEqual(new Set());
-          expect(vRems()).toEqual(new Set([a.signerKey, c.signerKey, d.signerKey]));
-          expect(eAddsHashes()).toEqual(new Set());
-          expect(eRemsHashes()).toEqual(new Set([addA.hash, addCToA.hash, addDToC.hash]));
-          expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-        });
-
-        test('succeeds when child already exists in tree', () => {
-          const messages = [addB, addCToB, addA, remA, addCToA];
-          for (const msg of messages) {
-            expect(set.merge(msg).isOk()).toBe(true);
-          }
-          expect(vAdds()).toEqual(new Set([b.signerKey]));
-          expect(vRems()).toEqual(new Set([a.signerKey, c.signerKey]));
-          expect(eAddsHashes()).toEqual(new Set([addB.hash]));
-          expect(eRemsHashes()).toEqual(new Set([addCToB.hash, addA.hash, addCToA.hash]));
-          expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-        });
-      });
-
-      describe('when child is added by different parents and then deleted by both parents', () => {
-        afterEach(() => {
-          expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey]));
-          expect(vRems()).toEqual(new Set([c.signerKey]));
-          expect(eAddsHashes()).toEqual(new Set([addA.hash, addB.hash]));
-          expect(eRemsHashes()).toEqual(new Set([addCToA.hash, addCToB.hash]));
-        });
-
-        test('succeeds when edges are both added and then both removed', () => {
-          const messages = [addA, addB, addCToA, addCToB, remCFromA, remCFromB];
-          for (const msg of messages) {
-            expect(set.merge(msg).isOk()).toBe(true);
-          }
-          expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-        });
-
-        test('succeeds when edges are added and removed sequentially', () => {
-          const messages = [addA, addB, addCToA, remCFromA, addCToB, remCFromB];
-          for (const msg of messages) {
-            expect(set.merge(msg).isOk()).toBe(true);
-          }
-          expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-        });
-      });
-
-      test('succeeds when custody address has already been removed', () => {
-        expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
-        expect(set.merge(addA).isOk()).toBe(true);
-        expect(vAdds()).toEqual(new Set());
-        expect(vRems()).toEqual(new Set([a.signerKey]));
-        expect(eAddsHashes()).toEqual(new Set());
-        expect(eRemsHashes()).toEqual(new Set([addA.hash]));
-        expect(messageHashes()).toEqual(new Set([addA.hash]));
-      });
-    });
-
-    describe('remove', () => {
-      test('succeeds with a valid SignerRemove message', () => {
-        expect(set.merge(addA).isOk()).toBe(true);
-        expect(set.merge(remA).isOk()).toBe(true);
-        expect(vAdds()).toEqual(new Set());
-        expect(vRems()).toEqual(new Set([a.signerKey]));
-        expect(eAddsHashes()).toEqual(new Set());
-        expect(eRemsHashes()).toEqual(new Set([addA.hash]));
-        expect(messageHashes()).toEqual(new Set([addA.hash, remA.hash]));
-      });
-
-      test("fails when child hasn't been added yet", () => {
-        expect(set.merge(remA).isOk()).toBe(false);
-        expect(vAdds()).toEqual(new Set());
-        expect(vRems()).toEqual(new Set());
-        expect(eAddsHashes()).toEqual(new Set());
-        expect(eRemsHashes()).toEqual(new Set());
-        expect(messageHashes()).toEqual(new Set());
-      });
-
-      test('succeeds and removes subtree', async () => {
-        const e = await generateEd25519Signer();
-        const addEToC = await Factories.SignerAdd.create({}, { transient: { signer: c, childSigner: e } });
-        const messages = [addA, addB, addCToA, addDToC, addEToC, remA];
-        for (const msg of messages) {
-          expect(set.merge(msg).isOk()).toBe(true);
-        }
-        expect(vAdds()).toEqual(new Set([b.signerKey]));
-        expect(vRems()).toEqual(new Set([a.signerKey, c.signerKey, d.signerKey, e.signerKey]));
-        expect(eAddsHashes()).toEqual(new Set([addB.hash]));
-        expect(eRemsHashes()).toEqual(new Set([addA.hash, addCToA.hash, addDToC.hash, addEToC.hash]));
-        expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-      });
-
-      test("fails when child doesn't belong to parent", async () => {
-        expect(set.merge(addA).isOk()).toBe(true);
-        expect(set.merge(addCToA).isOk()).toBe(true);
-        const remC = await Factories.SignerRemove.create(
-          { data: { body: { childKey: c.signerKey } } },
-          { transient: { signer: custody1 } }
-        );
-        expect(set.merge(remC).isOk()).toBe(false);
-        expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
-        expect(vRems()).toEqual(new Set());
-        expect(eAddsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-        expect(eRemsHashes()).toEqual(new Set());
-        expect(messageHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-      });
-
-      test('succeeds when child belongs to parent', () => {
-        expect(set.merge(addA).isOk()).toBe(true);
-        expect(set.merge(addCToA).isOk()).toBe(true);
-        expect(set.merge(remCFromA).isOk()).toBe(true);
-        expect(vAdds()).toEqual(new Set([a.signerKey]));
-        expect(vRems()).toEqual(new Set([c.signerKey]));
-        expect(eAddsHashes()).toEqual(new Set([addA.hash]));
-        expect(eRemsHashes()).toEqual(new Set([addCToA.hash]));
-        expect(messageHashes()).toEqual(new Set([addA.hash, addCToA.hash, remCFromA.hash]));
-      });
-
-      test('succeeds with duplicate signer remove message', () => {
-        expect(set.merge(addA).isOk()).toBe(true);
-        expect(set.merge(remA).isOk()).toBe(true);
-        expect(set.merge(remA).isOk()).toBe(true);
-        expect(vAdds()).toEqual(new Set());
-        expect(vRems()).toEqual(new Set([a.signerKey]));
-        expect(eAddsHashes()).toEqual(new Set());
-        expect(eRemsHashes()).toEqual(new Set([addA.hash]));
-        expect(messageHashes()).toEqual(new Set([addA.hash, remA.hash]));
-      });
-
-      test('a child is removed after its parent has already been removed', () => {
-        const messages = [addA, addCToA, remA, remCFromA];
-        for (const msg of messages) {
-          expect(set.merge(msg).isOk()).toBe(true);
-        }
-        expect(vAdds()).toEqual(new Set());
-        expect(vRems()).toEqual(new Set([a.signerKey, c.signerKey]));
-        expect(eAddsHashes()).toEqual(new Set());
-        expect(eRemsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
-        expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
-      });
-
-      test('succeeds when custody address has already been removed', () => {
-        expect(set.merge(addA).isOk()).toBe(true);
-        expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
-        expect(set.merge(remA).isOk()).toBe(true);
-        expect(vAdds()).toEqual(new Set());
-        expect(vRems()).toEqual(new Set([a.signerKey]));
-        expect(eAddsHashes()).toEqual(new Set());
-        expect(eRemsHashes()).toEqual(new Set([addA.hash]));
-        expect(messageHashes()).toEqual(new Set([addA.hash, remA.hash]));
-      });
-    });
-  });
+  // test('fails without custody address', () => {
+  //   expect(set.merge(addA).isOk()).toEqual(false);
+  //   expect(vAdds()).toEqual(new Set());
+  //   expect(vRems()).toEqual(new Set());
+  //   expect(eAddsHashes()).toEqual(new Set());
+  //   expect(eRems()).toEqual(new Map());
+  //   expect(messageHashes()).toEqual(new Set());
+  // });
+  // describe('with custody address', () => {
+  //   beforeEach(() => {
+  //     set.addCustody(custody1.signerKey);
+  //   });
+  //   describe('add', () => {
+  //     test('succeeds with a valid SignerAdd message', () => {
+  //       expect(set.merge(addA).isOk()).toEqual(true);
+  //       expect(vAdds()).toEqual(new Set([addA.data.body.childKey]));
+  //       expect(vRems()).toEqual(new Set());
+  //       expect(eAddsHashes()).toEqual(new Set([addA.hash]));
+  //       expect(eRems()).toEqual(new Map());
+  //       expect(messageHashes()).toEqual(new Set([addA.hash]));
+  //     });
+  //     test('succeeds with a duplicate valid SignerAdd message', () => {
+  //       expect(set.merge(addA).isOk()).toBe(true);
+  //       expect(set.merge(addA).isOk()).toBe(true);
+  //       expect(vAdds()).toEqual(new Set([addA.data.body.childKey]));
+  //       expect(vRems()).toEqual(new Set());
+  //       expect(eAddsHashes()).toEqual(new Set([addA.hash]));
+  //       expect(eRems()).toEqual(new Map());
+  //       expect(messageHashes()).toEqual(new Set([addA.hash]));
+  //     });
+  //     test('succeeds when adding a child to a parent', () => {
+  //       expect(set.merge(addA).isOk()).toBe(true);
+  //       expect(set.merge(addCToA).isOk()).toBe(true);
+  //       expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
+  //       expect(eAddsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
+  //       expect(messageHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
+  //     });
+  //     describe('when child already exists', () => {
+  //       describe('with different parent', () => {
+  //         beforeEach(() => {
+  //           expect(set.merge(addA).isOk()).toBe(true);
+  //           expect(set.merge(addB).isOk()).toBe(true);
+  //           expect(set.merge(addCToA).isOk()).toBe(true);
+  //           expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey, c.signerKey]));
+  //           expect(vRems()).toEqual(new Set());
+  //           expect(eAddsHashes()).toEqual(new Set([addA.hash, addB.hash, addCToA.hash]));
+  //           expect(eRemsHashes()).toEqual(new Set());
+  //         });
+  //         test('succeeds with a lower message hash but moves new edge to edgeRemoves', () => {
+  //           const addCToBLowerHash: SignerAdd = { ...addCToB, hash: addCToA.hash.slice(0, -1) };
+  //           expect(set.merge(addCToBLowerHash).isOk()).toBe(true);
+  //           expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey, c.signerKey]));
+  //           expect(vRems()).toEqual(new Set());
+  //           expect(eAddsHashes()).toEqual(new Set([addA.hash, addB.hash, addCToA.hash]));
+  //           expect(eRemsHashes()).toEqual(new Set([addCToBLowerHash.hash]));
+  //           expect(messageHashes()).toEqual(new Set([addA.hash, addB.hash, addCToA.hash, addCToBLowerHash.hash]));
+  //         });
+  //         test('succeeds with a higher message hash', () => {
+  //           const addCToBHigherHash: SignerAdd = { ...addCToB, hash: addCToA.hash + 'a' };
+  //           expect(set.merge(addCToBHigherHash).isOk()).toBe(true);
+  //           expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey, c.signerKey]));
+  //           expect(vRems()).toEqual(new Set());
+  //           expect(eAddsHashes()).toEqual(new Set([addA.hash, addB.hash, addCToBHigherHash.hash]));
+  //           expect(eRemsHashes()).toEqual(new Set([addCToA.hash]));
+  //           expect(messageHashes()).toEqual(new Set([addA.hash, addB.hash, addCToA.hash, addCToBHigherHash.hash]));
+  //         });
+  //       });
+  //       describe('with same parent', () => {
+  //         let addCToADuplicate: SignerAdd;
+  //         beforeAll(async () => {
+  //           addCToADuplicate = await Factories.SignerAdd.create({}, { transient: { signer: a, childSigner: c } });
+  //         });
+  //         beforeEach(() => {
+  //           expect(set.merge(addA).isOk()).toBe(true);
+  //           expect(set.merge(addCToA).isOk()).toBe(true);
+  //           expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
+  //           expect(vRems()).toEqual(new Set());
+  //           expect(eAddsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
+  //           expect(eRemsHashes()).toEqual(new Set());
+  //         });
+  //         test('succeeds with a lower message hash but does not update edgeAdds', () => {
+  //           const addCToADuplicateLowerHash: SignerAdd = { ...addCToADuplicate, hash: addCToA.hash.slice(0, -1) };
+  //           expect(set.merge(addCToADuplicateLowerHash).isOk()).toBe(true);
+  //           expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
+  //           expect(vRems()).toEqual(new Set());
+  //           expect(eAddsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
+  //           expect(eRemsHashes()).toEqual(new Set());
+  //           expect(messageHashes()).toEqual(new Set([addA.hash, addCToA.hash, addCToADuplicateLowerHash.hash]));
+  //         });
+  //         test('succeeds with a higher message hash', () => {
+  //           const addCToADuplicateHigherHash: SignerAdd = { ...addCToADuplicate, hash: addCToA.hash + 'z' };
+  //           expect(set.merge(addCToADuplicateHigherHash).isOk()).toBe(true);
+  //           expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
+  //           expect(vRems()).toEqual(new Set());
+  //           expect(eAddsHashes()).toEqual(new Set([addA.hash, addCToADuplicateHigherHash.hash]));
+  //           expect(eRemsHashes()).toEqual(new Set());
+  //           expect(messageHashes()).toEqual(new Set([addA.hash, addCToA.hash, addCToADuplicateHigherHash.hash]));
+  //         });
+  //       });
+  //     });
+  //     test('fails when parent does not exist', () => {
+  //       expect(vAdds().size).toEqual(0);
+  //       expect(set.merge(addCToA).isOk()).toBe(false);
+  //       expect(vAdds()).toEqual(new Set());
+  //       expect(vRems()).toEqual(new Set());
+  //       expect(eAddsHashes()).toEqual(new Set());
+  //       expect(eRemsHashes()).toEqual(new Set());
+  //       expect(messageHashes()).toEqual(new Set());
+  //     });
+  //     test('succeeds when child has already been deleted by another parent and moves new edge to edgeRemoves', () => {
+  //       const messages = [addA, addCToA, addB, remCFromA, addCToB];
+  //       for (const msg of messages) {
+  //         expect(set.merge(msg).isOk()).toBe(true);
+  //       }
+  //       expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey]));
+  //       expect(vRems()).toEqual(new Set([c.signerKey]));
+  //       expect(eAddsHashes()).toEqual(new Set([addA.hash, addB.hash]));
+  //       expect(eRemsHashes()).toEqual(new Set([addCToA.hash, addCToB.hash]));
+  //       expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
+  //     });
+  //     describe('cycle prevention', () => {
+  //       let addCHigherHash: SignerAdd;
+  //       let addAToCHigherHash: SignerAdd;
+  //       beforeAll(async () => {
+  //         addCHigherHash = await Factories.SignerAdd.create({}, { transient: { signer: custody1, childSigner: c } });
+  //         addCHigherHash.hash = addCToA.hash + 'a';
+  //         addAToCHigherHash = await Factories.SignerAdd.create({}, { transient: { signer: c, childSigner: a } });
+  //         addAToCHigherHash.hash = addA.hash + 'a';
+  //       });
+  //       // When all messages are accepted, the set converges
+  //       afterEach(() => {
+  //         expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
+  //         expect(vRems()).toEqual(new Set());
+  //         expect(eAddsHashes()).toEqual(new Set([addAToCHigherHash.hash, addCHigherHash.hash]));
+  //         expect(eRemsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
+  //         expect(messageHashes()).toEqual(
+  //           new Set([addA.hash, addCToA.hash, addAToCHigherHash.hash, addCHigherHash.hash])
+  //         );
+  //       });
+  //       test('succeeds after retry', () => {
+  //         expect(set.merge(addA).isOk()).toBe(true);
+  //         expect(set.merge(addCToA).isOk()).toBe(true);
+  //         expect(set.merge(addAToCHigherHash).isOk()).toBe(false);
+  //         expect(messageHashes()).not.toContain(addAToCHigherHash.hash);
+  //         expect(set.merge(addCHigherHash).isOk()).toBe(true);
+  //         expect(set.merge(addAToCHigherHash).isOk()).toBe(true); // Retry
+  //       });
+  //       test('succeeds when new edges do not create a cycle', () => {
+  //         expect(set.merge(addA).isOk()).toBe(true);
+  //         expect(set.merge(addCHigherHash).isOk()).toBe(true);
+  //         expect(set.merge(addCToA).isOk()).toBe(true);
+  //         expect(set.merge(addAToCHigherHash).isOk()).toBe(true);
+  //       });
+  //       test('succeeds when edge that would create a cycle has lower hash', () => {
+  //         expect(set.merge(addCHigherHash).isOk()).toBe(true);
+  //         expect(set.merge(addAToCHigherHash).isOk()).toBe(true);
+  //         expect(set.merge(addCToA).isOk()).toBe(true); // lower hash prevents cycle in edgeAdds
+  //         expect(set.merge(addA).isOk()).toBe(true);
+  //       });
+  //     });
+  //     test('succeeds when creating a cycle in edgeRemoves graph', async () => {
+  //       const addCToBHigherHash: SignerAdd = { ...addCToB, hash: addCToA.hash + 'a' };
+  //       const addAToCHigherHash = await Factories.SignerAdd.create({}, { transient: { signer: c, childSigner: a } });
+  //       addAToCHigherHash.hash = addA.hash + 'a';
+  //       const messages = [addA, addB, addCToA, addCToBHigherHash, addAToCHigherHash];
+  //       for (const msg of messages) {
+  //         expect(set.merge(msg).isOk()).toBe(true);
+  //       }
+  //       expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey, c.signerKey]));
+  //       expect(vRems()).toEqual(new Set());
+  //       expect(eAddsHashes()).toEqual(new Set([addB.hash, addAToCHigherHash.hash, addCToBHigherHash.hash]));
+  //       expect(eRemsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
+  //       expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
+  //     });
+  //     describe('when adding a child to subtree that is already removed', () => {
+  //       test('succeeds with new child', () => {
+  //         const messages = [addA, addCToA, remA, addDToC];
+  //         for (const msg of messages) {
+  //           expect(set.merge(msg).isOk()).toBe(true);
+  //         }
+  //         expect(vAdds()).toEqual(new Set());
+  //         expect(vRems()).toEqual(new Set([a.signerKey, c.signerKey, d.signerKey]));
+  //         expect(eAddsHashes()).toEqual(new Set());
+  //         expect(eRemsHashes()).toEqual(new Set([addA.hash, addCToA.hash, addDToC.hash]));
+  //         expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
+  //       });
+  //       test('succeeds when child already exists in tree', () => {
+  //         const messages = [addB, addCToB, addA, remA, addCToA];
+  //         for (const msg of messages) {
+  //           expect(set.merge(msg).isOk()).toBe(true);
+  //         }
+  //         expect(vAdds()).toEqual(new Set([b.signerKey]));
+  //         expect(vRems()).toEqual(new Set([a.signerKey, c.signerKey]));
+  //         expect(eAddsHashes()).toEqual(new Set([addB.hash]));
+  //         expect(eRemsHashes()).toEqual(new Set([addCToB.hash, addA.hash, addCToA.hash]));
+  //         expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
+  //       });
+  //     });
+  //     describe('when child is added by different parents and then deleted by both parents', () => {
+  //       afterEach(() => {
+  //         expect(vAdds()).toEqual(new Set([a.signerKey, b.signerKey]));
+  //         expect(vRems()).toEqual(new Set([c.signerKey]));
+  //         expect(eAddsHashes()).toEqual(new Set([addA.hash, addB.hash]));
+  //         expect(eRemsHashes()).toEqual(new Set([addCToA.hash, addCToB.hash]));
+  //       });
+  //       test('succeeds when edges are both added and then both removed', () => {
+  //         const messages = [addA, addB, addCToA, addCToB, remCFromA, remCFromB];
+  //         for (const msg of messages) {
+  //           expect(set.merge(msg).isOk()).toBe(true);
+  //         }
+  //         expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
+  //       });
+  //       test('succeeds when edges are added and removed sequentially', () => {
+  //         const messages = [addA, addB, addCToA, remCFromA, addCToB, remCFromB];
+  //         for (const msg of messages) {
+  //           expect(set.merge(msg).isOk()).toBe(true);
+  //         }
+  //         expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
+  //       });
+  //     });
+  //     test('succeeds when custody address has already been removed', () => {
+  //       expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
+  //       expect(set.merge(addA).isOk()).toBe(true);
+  //       expect(vAdds()).toEqual(new Set());
+  //       expect(vRems()).toEqual(new Set([a.signerKey]));
+  //       expect(eAddsHashes()).toEqual(new Set());
+  //       expect(eRemsHashes()).toEqual(new Set([addA.hash]));
+  //       expect(messageHashes()).toEqual(new Set([addA.hash]));
+  //     });
+  //   });
+  //   describe('remove', () => {
+  //     test('succeeds with a valid SignerRemove message', () => {
+  //       expect(set.merge(addA).isOk()).toBe(true);
+  //       expect(set.merge(remA).isOk()).toBe(true);
+  //       expect(vAdds()).toEqual(new Set());
+  //       expect(vRems()).toEqual(new Set([a.signerKey]));
+  //       expect(eAddsHashes()).toEqual(new Set());
+  //       expect(eRemsHashes()).toEqual(new Set([addA.hash]));
+  //       expect(messageHashes()).toEqual(new Set([addA.hash, remA.hash]));
+  //     });
+  //     test("fails when child hasn't been added yet", () => {
+  //       expect(set.merge(remA).isOk()).toBe(false);
+  //       expect(vAdds()).toEqual(new Set());
+  //       expect(vRems()).toEqual(new Set());
+  //       expect(eAddsHashes()).toEqual(new Set());
+  //       expect(eRemsHashes()).toEqual(new Set());
+  //       expect(messageHashes()).toEqual(new Set());
+  //     });
+  //     test('succeeds and removes subtree', async () => {
+  //       const e = await generateEd25519Signer();
+  //       const addEToC = await Factories.SignerAdd.create({}, { transient: { signer: c, childSigner: e } });
+  //       const messages = [addA, addB, addCToA, addDToC, addEToC, remA];
+  //       for (const msg of messages) {
+  //         expect(set.merge(msg).isOk()).toBe(true);
+  //       }
+  //       expect(vAdds()).toEqual(new Set([b.signerKey]));
+  //       expect(vRems()).toEqual(new Set([a.signerKey, c.signerKey, d.signerKey, e.signerKey]));
+  //       expect(eAddsHashes()).toEqual(new Set([addB.hash]));
+  //       expect(eRemsHashes()).toEqual(new Set([addA.hash, addCToA.hash, addDToC.hash, addEToC.hash]));
+  //       expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
+  //     });
+  //     test("fails when child doesn't belong to parent", async () => {
+  //       expect(set.merge(addA).isOk()).toBe(true);
+  //       expect(set.merge(addCToA).isOk()).toBe(true);
+  //       const remC = await Factories.SignerRemove.create(
+  //         { data: { body: { childKey: c.signerKey } } },
+  //         { transient: { signer: custody1 } }
+  //       );
+  //       expect(set.merge(remC).isOk()).toBe(false);
+  //       expect(vAdds()).toEqual(new Set([a.signerKey, c.signerKey]));
+  //       expect(vRems()).toEqual(new Set());
+  //       expect(eAddsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
+  //       expect(eRemsHashes()).toEqual(new Set());
+  //       expect(messageHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
+  //     });
+  //     test('succeeds when child belongs to parent', () => {
+  //       expect(set.merge(addA).isOk()).toBe(true);
+  //       expect(set.merge(addCToA).isOk()).toBe(true);
+  //       expect(set.merge(remCFromA).isOk()).toBe(true);
+  //       expect(vAdds()).toEqual(new Set([a.signerKey]));
+  //       expect(vRems()).toEqual(new Set([c.signerKey]));
+  //       expect(eAddsHashes()).toEqual(new Set([addA.hash]));
+  //       expect(eRemsHashes()).toEqual(new Set([addCToA.hash]));
+  //       expect(messageHashes()).toEqual(new Set([addA.hash, addCToA.hash, remCFromA.hash]));
+  //     });
+  //     test('succeeds with duplicate signer remove message', () => {
+  //       expect(set.merge(addA).isOk()).toBe(true);
+  //       expect(set.merge(remA).isOk()).toBe(true);
+  //       expect(set.merge(remA).isOk()).toBe(true);
+  //       expect(vAdds()).toEqual(new Set());
+  //       expect(vRems()).toEqual(new Set([a.signerKey]));
+  //       expect(eAddsHashes()).toEqual(new Set());
+  //       expect(eRemsHashes()).toEqual(new Set([addA.hash]));
+  //       expect(messageHashes()).toEqual(new Set([addA.hash, remA.hash]));
+  //     });
+  //     test('a child is removed after its parent has already been removed', () => {
+  //       const messages = [addA, addCToA, remA, remCFromA];
+  //       for (const msg of messages) {
+  //         expect(set.merge(msg).isOk()).toBe(true);
+  //       }
+  //       expect(vAdds()).toEqual(new Set());
+  //       expect(vRems()).toEqual(new Set([a.signerKey, c.signerKey]));
+  //       expect(eAddsHashes()).toEqual(new Set());
+  //       expect(eRemsHashes()).toEqual(new Set([addA.hash, addCToA.hash]));
+  //       expect(messageHashes()).toEqual(new Set(messages.map((msg) => msg.hash)));
+  //     });
+  //     test('succeeds when custody address has already been removed', () => {
+  //       expect(set.merge(addA).isOk()).toBe(true);
+  //       expect(set.removeCustody(custody1.signerKey).isOk()).toBe(true);
+  //       expect(set.merge(remA).isOk()).toBe(true);
+  //       expect(vAdds()).toEqual(new Set());
+  //       expect(vRems()).toEqual(new Set([a.signerKey]));
+  //       expect(eAddsHashes()).toEqual(new Set());
+  //       expect(eRemsHashes()).toEqual(new Set([addA.hash]));
+  //       expect(messageHashes()).toEqual(new Set([addA.hash, remA.hash]));
+  //     });
+  //   });
+  // });
 });

--- a/src/sets/signerSet.ts
+++ b/src/sets/signerSet.ts
@@ -1,6 +1,6 @@
 import { Result, ok, err } from 'neverthrow';
-import { SignerAdd, SignerMessage, SignerRemove } from '~/types';
-import { isSignerAdd, isSignerRemove } from '~/types/typeguards';
+import { CustodyAddEvent, CustodyRemoveAll, SignerAdd, SignerMessage, SignerRemove } from '~/types';
+import { isCustodyRemoveAll, isSignerAdd, isSignerRemove } from '~/types/typeguards';
 import { hashCompare } from '~/utils';
 
 /*   
@@ -11,79 +11,35 @@ import { hashCompare } from '~/utils';
 
   This implementation uses a modified 2P2P set. There are four sets in total:
 
-  (1) vertexAdds: add set for vertices
-  (2) vertexRemoves: remove set for vertices
-  (3) edgeAdds: add set for edges
-  (4) edgeremoves: remove set for edges
-  
-  The design diverges from a conventional 2P2P set in two ways:
-
-  (1) Vertices and edges are moved between sets, so a given vertex or edge can only exist in 
-      its respective adds or removes set 
-  (2) The edges set store the edge tuple (parentKey, childKey) as well as the hash of the SignerAdd
-      message that added that edge to the graph
-
-  In practice, there is a constraint that the edges add set is a tree and the edges 
-  remove set is a rooted directed graph. But that constraint is only a bi-product of the add
-  and remove methods, and it is not enforced by the data structure. This implementation 
-  favors keeping the edgeAdds and edgeRemoves data structure the same, which makes the sets
-  easier to compare. But this decision has two downsides:
-
-  (1) Tree and edge traversal is not as efficient as it could be. See the getEdgesByChild 
-      and getEdgesbyParent methods which filter keys in the edges maps by the child or parent 
-      members of the tuple.
-  (2) At points in the code where we need to get the parent of a vertex b in edgeAdds, we
-      loop through edges in edgeAdds where (*,b) even though practically we know there is only
-      one edge that fits that criteria. See the removeSubtree method for an example.
+  (1) custodyAdds: add set for custody addresses
+  (2) custodyRemoves: remove set for custody addresses
+  (3) signerAdds: add set for delegate signers
+  (4) signerRemoves: remove set for delegate signers
 */
 class SignerSet {
-  private _custodyAdds: Set<string>; // custody address
-  private _custodyRemoves: Set<string>; // custody address
-  private _vertexAdds: Set<string>; // pubKey
-  private _vertexRemoves: Set<string>; // pubKey
-  private _edgeAdds: Map<string, string>; // <parentKey, childKey>, hash
-  private _edgeRemoves: Map<string, string>; // <parentKey, childKey>, hash
-  private _messages: Map<string, SignerMessage>; // message hash => SignerAdd | SignerRemove
+  private _custodyAdds: Map<string, CustodyAddEvent>;
+  private _custodyRemoves: Map<string, CustodyRemoveAll>;
+  private _signerAdds: Map<string, SignerAdd>;
+  private _signerRemoves: Map<string, SignerRemove>;
 
   constructor() {
-    this._custodyAdds = new Set();
-    this._custodyRemoves = new Set();
-    this._vertexAdds = new Set();
-    this._vertexRemoves = new Set();
-    this._edgeAdds = new Map();
-    this._edgeRemoves = new Map();
-    this._messages = new Map();
+    this._custodyAdds = new Map();
+    this._custodyRemoves = new Map();
+    this._signerAdds = new Map();
+    this._signerRemoves = new Map();
   }
 
   // TODO: add more helper functions as we integrate signer set into engine
-
-  getCustodyAddresses(): string[] {
-    return Array.from(this._custodyAdds);
-  }
-
-  getDelegates(): string[] {
-    return Array.from(this._vertexAdds);
-  }
-
-  getAllDelegates(): string[] {
-    return Array.from(this._vertices);
-  }
 
   sanitizeKey(key: string): string {
     return key.toLowerCase();
   }
 
-  constructEdgeKey(parentKey: string, childKey: string): string {
-    return [this.sanitizeKey(parentKey), this.sanitizeKey(childKey)].toString();
-  }
-
-  deconstructEdgeKey(edgeKey: string): { parentKey: string; childKey: string } {
-    const [parentKey, childKey] = edgeKey.split(',');
-    return { parentKey, childKey };
-  }
-
   merge(message: SignerMessage): Result<void, string> {
-    if (this._messages.get(message.hash)) return ok(undefined); // Duplicate message
+    // if (this._messages.get(message.hash)) return ok(undefined); // Duplicate message
+    if (isCustodyRemoveAll(message)) {
+      return this.mergeCustodyRemoveAll(message);
+    }
 
     if (isSignerRemove(message)) {
       return this.mergeSignerRemove(message);
@@ -99,381 +55,201 @@ class SignerSet {
   /**
    * addCustody adds a custody address to custodyAdds set.
    *
-   * @param custodyAddress - custody address to add to custodyAdds set
+   * @param event - event from Farcaster ID Registry
    */
-  addCustody(custodyAddress: string): Result<void, string> {
-    const sanitizedAddress = this.sanitizeKey(custodyAddress);
+  addCustody(event: CustodyAddEvent): Result<void, string> {
+    const sanitizedAddress = this.sanitizeKey(event.custodyAddress);
 
-    // No-op if address already exists in custodyAdds
-    if (this._custodyAdds.has(sanitizedAddress)) return ok(undefined);
+    const existingCustodyAdd = this._custodyAdds.get(sanitizedAddress);
+    if (existingCustodyAdd) {
+      // If existing block number wins
+      if (existingCustodyAdd.blockNumber > event.blockNumber) {
+        return ok(undefined); // No-op
+      }
 
-    // Fail if address already exists as a delegate
-    if (this._vertices.has(sanitizedAddress))
-      return err('SignerSet.addCustody: custodyAddress already exists as a delegate');
+      // If new block number wins, let through
 
-    // Fail if address has already been removed
-    if (this._custodyRemoves.has(sanitizedAddress)) return err('SignerSet.addCustody: custodyAddress has been removed');
-
-    // Add address to custodyAdds set
-    this._custodyAdds.add(sanitizedAddress);
-    return ok(undefined);
-  }
-
-  /**
-   * removeCustody moves a custody address from the custodyAdds set to the custodyRemoves set.
-   *
-   * @param custodyAddress - custody address to move to custodyRemoves set
-   */
-  removeCustody(custodyAddress: string): Result<void, string> {
-    const sanitizedAddress = this.sanitizeKey(custodyAddress);
-
-    // No-op if address already exists in custodyRemoves
-    if (this._custodyRemoves.has(sanitizedAddress)) return ok(undefined);
-
-    // Fail if address does not exist in custodyAdds
-    if (!this._custodyAdds.has(sanitizedAddress)) return err('SignerSet.removeCustody: custodyAddress does not exist');
-
-    // For each edge (custody, *), remove subtree
-    for (const edgeKey of this._edgeAddsByParent.get(sanitizedAddress) || new Set()) {
-      const { childKey } = this.deconstructEdgeKey(edgeKey);
-      const res = this.removeSubtree(childKey);
-      if (res.isErr()) return res;
+      // If block number is the same
+      // TODO
     }
 
-    // Move address from custodyAdds to custodyRemoves
-    this._custodyAdds.delete(sanitizedAddress);
-    this._custodyRemoves.add(sanitizedAddress);
-    return ok(undefined);
+    const existingCustodyRemove = this._custodyRemoves.get(sanitizedAddress);
+    if (existingCustodyRemove) {
+      // Get custody add event for signer of CustodyRemove message
+      const sanitizedCompetingAddress = this.sanitizeKey(existingCustodyRemove.signer);
+      const competingCustodyAddEvent = this._custodyAdds.get(sanitizedCompetingAddress);
+      if (competingCustodyAddEvent) {
+        // If existing block number wins
+        if (competingCustodyAddEvent.blockNumber > event.blockNumber) {
+          return ok(undefined); // No-op
+        }
+
+        // If new block number wins
+        if (competingCustodyAddEvent.blockNumber < event.blockNumber) {
+          this._custodyRemoves.delete(sanitizedAddress);
+        }
+
+        // If block number is the same
+        // TODO
+      }
+    }
+
+    this._custodyAdds.set(sanitizedAddress, event);
+    return ok(undefined); // Success
   }
 
   /**
    * Private Methods
    */
 
-  private get _vertices() {
-    return new Set([...this._vertexAdds, ...this._vertexRemoves]);
-  }
-
-  private get _edges() {
-    return new Map([...this._edgeAdds, ...this._edgeRemoves]);
-  }
-
-  private get _custodyAddresses() {
-    return new Set([...this._custodyAdds, ...this._custodyRemoves]);
-  }
-
-  private get _edgeAddsByChild() {
-    return this.getEdgesByChild(this._edgeAdds);
-  }
-
-  private get _edgeRemovesByChild() {
-    return this.getEdgesByChild(this._edgeRemoves);
-  }
-
-  private get _edgesByChild() {
-    return this.getEdgesByChild(this._edges);
-  }
-
-  private get _edgeAddsByParent() {
-    return this.getEdgesByParent(this._edgeAdds);
-  }
-
-  private get _edgeRemovesByParent() {
-    return this.getEdgesByParent(this._edgeRemoves);
-  }
-
-  private get _edgesByParent() {
-    return this.getEdgesByParent(this._edges);
-  }
-
   /**
-   * getEdgesByChild returns a Map where each key is a child vertex in the input edges set, and each value
-   * is a set of edges (as edge tuple strings) that contain the childKey as the child.
+   * mergeCustodyRemoveAll moves all address in custodyAdds with a block number before the
+   * signer of the CustodyRemoveAll message to custodyRemoves
    *
-   * For example, getEdgesByChild({"parentA,childB" => "hashC"}) => {"childB" => Set(["parentA,childB"])}
-   *
-   * @param edges - a map of (parent, child) tuple strings to message hashes (i.e. _edgeAdds, _edgeRemoves, _edges)
+   * @param message - CustodyRemoveAll message
    */
-  private getEdgesByChild(edges: Map<string, string>) {
-    const byChildMap = new Map<string, Set<string>>();
-    for (const edgeKey of edges.keys()) {
-      const { childKey } = this.deconstructEdgeKey(edgeKey);
-      const existingSet = byChildMap.get(childKey) || new Set();
-      existingSet.add(edgeKey);
-      byChildMap.set(childKey, existingSet);
+  private mergeCustodyRemoveAll(message: CustodyRemoveAll): Result<void, string> {
+    const sanitizedAddress = this.sanitizeKey(message.signer);
+
+    // If custodyAddress exists in custodyRemoves, no-op
+    if (this._custodyRemoves.has(sanitizedAddress)) return ok(undefined);
+
+    // If custodyAddress does not exist in custodyAdds, fail
+    const custodyAddEvent = this._custodyAdds.get(sanitizedAddress);
+    if (!custodyAddEvent) return err('SignerSet.mergeCustodyRemoveAll: custodyAddress does not exist');
+
+    // For each custody address, remove if block number is before signer
+    const removedCustodyAddresses = [];
+    for (const [address, addEvent] of this._custodyAdds) {
+      if (addEvent.blockNumber < custodyAddEvent.blockNumber) {
+        this._custodyAdds.delete(address);
+        this._custodyRemoves.set(address, message);
+        removedCustodyAddresses.push(address);
+      }
     }
-    return byChildMap;
+
+    // Revoke removed custody addresses
+    for (const custodyAddress of removedCustodyAddresses) {
+      // TODO: revoke
+    }
+
+    return ok(undefined);
   }
 
   /**
-   * getEdgesByParent returns a Map where each key is a parent vertex in the input edges set, and each value
-   * is a set of edges (as edge tuple strings) that contain the parentKey as the parent.
-   *
-   * For example, getEdgesByParent({"parentA,childB" => "hashC"}) => {"parentA" => Set(["parentA,childB"])}
-   *
-   * @param edges - a map of (parent, child) tuple strings to message hashes (i.e. _edgeAdds, _edgeRemoves, _edges)
-   */
-  private getEdgesByParent(edges: Map<string, string>) {
-    const byParentMap = new Map<string, Set<string>>();
-    for (const edgeKey of edges.keys()) {
-      const { parentKey } = this.deconstructEdgeKey(edgeKey);
-      const existingSet = byParentMap.get(parentKey) || new Set();
-      existingSet.add(edgeKey);
-      byParentMap.set(parentKey, existingSet);
-    }
-    return byParentMap;
-  }
-
-  /**
-   * mergeSignerAdd calls add using the contents of the supplied SignerAdd message and adds message
-   * to the messages map if add was successful
+   * mergeSignerAdd tries to add a new signer with a SignerAdd message
    *
    * @param message - a SignerAdd message
    */
   private mergeSignerAdd(message: SignerAdd): Result<void, string> {
-    const parentKey = this.sanitizeKey(message.signer);
-    const childKey = this.sanitizeKey(message.data.body.childKey);
+    const custodyAddress = this.sanitizeKey(message.signer);
+    const signerKey = this.sanitizeKey(message.data.body.childKey);
 
-    const res = this.add(parentKey, childKey, message.hash);
-    if (res.isErr()) return res;
+    // If custody address has been removed
+    if (this._custodyRemoves.has(custodyAddress))
+      return err('SignerSet.mergeSignerAdd: custodyAddress has been removed');
 
-    this._messages.set(message.hash, message);
+    // If custody address is missing
+    const custodyAddEvent = this._custodyAdds.get(custodyAddress);
+    if (!custodyAddEvent) return err('SignerSet.mergeSignerAdd: custodyAddress does not exist');
+
+    const existingSignerAdd = this._signerAdds.get(signerKey);
+    if (existingSignerAdd) {
+      const existingCustodyAddEvent = this._custodyAdds.get(this.sanitizeKey(existingSignerAdd.signer));
+
+      if (existingCustodyAddEvent) {
+        // If existing block number wins
+        if (existingCustodyAddEvent.blockNumber > custodyAddEvent.blockNumber) {
+          return ok(undefined); // No-op
+        }
+
+        // If new block number wins, continue execution
+
+        // If block numbers are the same
+        // TODO
+      }
+    }
+
+    const existingSignerRemove = this._signerRemoves.get(signerKey);
+    if (existingSignerRemove) {
+      const existingCustodyAddEvent = this._custodyAdds.get(this.sanitizeKey(existingSignerRemove.signer));
+
+      if (existingCustodyAddEvent) {
+        // If existing block number wins
+        if (existingCustodyAddEvent.blockNumber > custodyAddEvent.blockNumber) {
+          return ok(undefined); // No-op
+        }
+
+        // If new block number wins, remove signer from removes
+        if (existingCustodyAddEvent.blockNumber < custodyAddEvent.blockNumber) {
+          this._signerRemoves.delete(signerKey);
+        }
+
+        // If block numbers are the same
+        // TODO
+      }
+    }
+
+    this._signerAdds.set(signerKey, message);
     return ok(undefined);
   }
 
   /**
-   * mergeSignerRemove calls remove using the contents of the supplied SignerRemove message and adds message
-   * to the messages map if remove was successful
+   * mergeSignerRemove tries to remove a signer with a SignerRemove message
    *
    * @param message - a SignerRemove message
    */
   private mergeSignerRemove(message: SignerRemove): Result<void, string> {
-    const parentKey = this.sanitizeKey(message.signer);
-    const childKey = this.sanitizeKey(message.data.body.childKey);
+    const custodyAddress = this.sanitizeKey(message.signer);
+    const signerKey = this.sanitizeKey(message.data.body.childKey);
 
-    const res = this.remove(parentKey, childKey);
-    if (res.isErr()) return res;
+    // If custody address has been removed
+    if (this._custodyRemoves.has(custodyAddress))
+      return err('SignerSet.mergeSignerRemove: custodyAddress has been removed');
 
-    this._messages.set(message.hash, message);
-    return ok(undefined);
-  }
+    // If custody address is missing
+    const custodyAddEvent = this._custodyAdds.get(custodyAddress);
+    if (!custodyAddEvent) return err('SignerSet.mergeSignerRemove: custodyAddress does not exist');
 
-  /**
-   * add attemps to add childKey as a delegate of parentKey. See inline comments for detailed behavior.
-   *
-   * @param parentKey - sanitized parent key (either custody address or delegate public key)
-   * @param childKey - sanitized child public key
-   * @param hash - relevant SignerAdd message hash
-   */
-  private add(parentKey: string, childKey: string, hash: string): Result<void, string> {
-    const edgeKey = this.constructEdgeKey(parentKey, childKey);
+    const existingSignerRemove = this._signerRemoves.get(signerKey);
+    if (existingSignerRemove) {
+      const existingCustodyAddEvent = this._custodyAdds.get(this.sanitizeKey(existingSignerRemove.signer));
 
-    // If parent is missing
-    if (!this._vertices.has(parentKey) && !this._custodyAddresses.has(parentKey)) {
-      return err('SignerSet.add: parent does not exist in graph');
-    }
-
-    // If parent and child are the same
-    if (parentKey === childKey) return err('SignerSet.add: parent and child must be different');
-
-    // If child is a custody address
-    if (this._custodyAddresses.has(childKey)) return err('SignerSet.add: child cannot be a custody signer');
-
-    // If (parent, child) exists in eAdds
-    const existingEdgeAddsHash = this._edgeAdds.get(edgeKey);
-    if (existingEdgeAddsHash) {
-      // Update eAdds with higher order hash
-      if (hashCompare(existingEdgeAddsHash, hash) < 0) {
-        this._edgeAdds.set(edgeKey, hash);
-      }
-      return ok(undefined);
-    }
-
-    // If (parent, child) exists in eRems
-    const existingEdgeRemovesHash = this._edgeRemoves.get(edgeKey);
-    if (existingEdgeRemovesHash) {
-      // Update eRems with higher order hash
-      if (hashCompare(existingEdgeRemovesHash, hash) < 0) {
-        this._edgeRemoves.set(edgeKey, hash);
-      }
-      return ok(undefined);
-    }
-
-    // If parent exists in vAdds or custodyAdds
-    if (this._vertexAdds.has(parentKey) || this._custodyAdds.has(parentKey)) {
-      // If child does not exist in vertices
-      if (!this._vertices.has(childKey)) {
-        // Add child to vAdds and (a,b) to eAdds
-        this._vertexAdds.add(childKey);
-        this._edgeAdds.set(edgeKey, hash);
-
-        return ok(undefined);
-      }
-
-      // If child exists in vAdds
-      else if (this._vertexAdds.has(childKey)) {
-        // For each edge (*, child) in edgeAdds (though there should be only one parent)
-        const parentEdges = this._edgeAddsByChild.get(childKey) || new Set();
-        for (const existingEdgeKey of parentEdges) {
-          const existingEdgeHash = this._edgeAdds.get(existingEdgeKey);
-          if (!existingEdgeHash) return err('SignerSet.add: unexpected state');
-
-          // If existing message wins
-          if (hashCompare(existingEdgeHash, hash) > 0) {
-            // Add (parent, child) to eRems
-            this._edgeRemoves.set(edgeKey, hash);
-          }
-
-          // If new message wins
-          else {
-            /**
-             * Get all ascendents of parentKey in edgeAdds in order to prevent the new edge from
-             * creating a cycle in edgeAdds. The new edge (parentKey, childKey) will create
-             * a cycle if childKey already exists in the ascendents of parentKey.
-             */
-            const parentsOfParent: string[] = [];
-            let parentEdgesToTraverse = this._edgeAddsByChild.get(parentKey) || new Set();
-            while (parentEdgesToTraverse.size > 0) {
-              const newParentEdgesToTraverse = new Set<string>();
-              parentEdgesToTraverse.forEach((edgeKey) => {
-                const { parentKey } = this.deconstructEdgeKey(edgeKey);
-                parentsOfParent.push(parentKey);
-                // Stop traversal once a custody signer is found
-                if (!this._custodyAddresses.has(parentKey)) {
-                  (this._edgeAddsByChild.get(parentKey) || new Set()).forEach((parentEdgeKey) =>
-                    newParentEdgesToTraverse.add(parentEdgeKey)
-                  );
-                }
-              });
-              parentEdgesToTraverse = newParentEdgesToTraverse;
-            }
-
-            // If parents of parentKey includes childKey (i.e. a cycle)
-            if (parentsOfParent.includes(childKey)) return err('SignerSet.add: cycle detected');
-
-            // Move existing edge to eRems
-            this._edgeAdds.delete(existingEdgeKey);
-            this._edgeRemoves.set(existingEdgeKey, existingEdgeHash);
-            // Add (parent, child) to eAdds
-            this._edgeAdds.set(edgeKey, hash);
-          }
+      if (existingCustodyAddEvent) {
+        // If existing block number wins
+        if (existingCustodyAddEvent.blockNumber > custodyAddEvent.blockNumber) {
+          return ok(undefined); // No-op
         }
 
-        return ok(undefined);
-      }
+        // If new block number wins, continue execution
 
-      // If child exists in vRems
-      else if (this._vertexRemoves.has(childKey)) {
-        // Add (parent, child) to eRems
-        this._edgeRemoves.set(edgeKey, hash);
-        return ok(undefined);
+        // If block numbers are the same
+        // TODO
       }
     }
 
-    // If parent exists in vRems or custodyRems
-    else if (this._vertexRemoves.has(parentKey) || this._custodyRemoves.has(parentKey)) {
-      // If child does not exist in vertices
-      if (!this._vertices.has(childKey)) {
-        // Add child to vRems
-        this._vertexRemoves.add(childKey);
-        // Add (parent, child) to eRems
-        this._edgeRemoves.set(edgeKey, hash);
-        return ok(undefined);
-      }
+    const existingSignerAdd = this._signerAdds.get(signerKey);
+    if (existingSignerAdd) {
+      const existingCustodyAddEvent = this._custodyAdds.get(this.sanitizeKey(existingSignerAdd.signer));
 
-      // If child exists in vAdds
-      else if (this._vertexAdds.has(childKey)) {
-        // Add (parent, child) to eRems
-        this._edgeRemoves.set(edgeKey, hash);
+      if (existingCustodyAddEvent) {
+        // If existing block number wins
+        if (existingCustodyAddEvent.blockNumber > custodyAddEvent.blockNumber) {
+          return ok(undefined); // No-op
+        }
 
-        // For all (child,*) in edges, remove subtree (child and all children vertices and edges)
-        this.removeSubtree(childKey);
+        // If new block number wins, remove signer from signerAdds
+        if (existingCustodyAddEvent.blockNumber < custodyAddEvent.blockNumber) {
+          this._signerAdds.delete(signerKey);
+        }
 
-        return ok(undefined);
-      }
-
-      // If child exists in vRems
-      else if (this._vertexRemoves.has(childKey)) {
-        // Add (parent,child) to eRems
-        this._edgeRemoves.set(edgeKey, hash);
-
-        return ok(undefined);
+        // If block numbers are the same
+        // TODO
       }
     }
 
-    return ok(undefined);
-  }
-
-  /**
-   * remove attempts to remove childKey as a delegate of parentKey. See inline comments for detailed behavior.
-   *
-   * @param parentKey - sanitized parent key (either custody address or delegate public key)
-   * @param childKey - sanitized child public key
-   */
-  private remove(parentKey: string, childKey: string): Result<void, string> {
-    const edgeKey = this.constructEdgeKey(parentKey, childKey);
-
-    // If (parent, child) does not exist in graph
-    if (!this._edges.has(edgeKey)) return err('SignerSet.remove: edge does not exist');
-
-    // If child exists in vAdds
-    if (this._vertexAdds.has(childKey)) {
-      // Remove subtree
-      const res = this.removeSubtree(childKey);
-      if (res.isErr()) return res;
-
-      // For all (child,*) in edges, remove edge
-      (this._edgesByParent.get(childKey) || new Set()).forEach((edgeKey) => {
-        this.removeEdge(edgeKey);
-      });
-
-      return ok(undefined);
-    }
-
-    // If child exists in vRems
-    if (this._vertexRemoves.has(childKey)) {
-      return ok(undefined);
-    }
-
-    return ok(undefined);
-  }
-
-  /**
-   * removeEdge calls remove, pulling the parentKey and childKey arguments
-   * from the supplied edgeKey, which is a (parent, child) tuple string
-   */
-  private removeEdge(edgeKey: string): Result<void, string> {
-    const { parentKey, childKey } = this.deconstructEdgeKey(edgeKey);
-    return this.remove(parentKey, childKey);
-  }
-
-  /**
-   * removeSubtree performs three operations given a public key (root of the subtree):
-   * 1. Move parent edge (*,root) from eAdds to eRems
-   * 2. Move root to vRems
-   * 3. For all edges (root,*), run remove(root,*), recursively removing the descendents of root
-   */
-  private removeSubtree(rootPubKey: string): Result<void, string> {
-    // For all (*,root) in eAdds, move to eRems
-    (this._edgesByChild.get(rootPubKey) || new Set()).forEach((edgeKey) => {
-      const existingHash = this._edgeAdds.get(edgeKey);
-      if (!existingHash) return err('SignerSet.removeSubtree: unexpected state');
-
-      this._edgeAdds.delete(edgeKey);
-      this._edgeRemoves.set(edgeKey, existingHash);
-    });
-
-    // Move root to vRems
-    this._vertexAdds.delete(rootPubKey);
-    this._vertexRemoves.add(rootPubKey);
-
-    // Remove all edges where rootPubKey is parent
-    const parentEdges = this._edgesByParent.get(rootPubKey) || new Set();
-    parentEdges.forEach((edgeKey) => {
-      const res = this.removeEdge(edgeKey);
-      if (res.isErr()) return res;
-    });
-
+    this._signerRemoves.set(signerKey, message);
+    // TODO: revoke signerKey
     return ok(undefined);
   }
 
@@ -482,17 +258,10 @@ class SignerSet {
    */
 
   _reset(): void {
-    this._custodyAdds = new Set();
-    this._custodyRemoves = new Set();
-    this._vertexAdds = new Set();
-    this._vertexRemoves = new Set();
-    this._edgeAdds = new Map();
-    this._edgeRemoves = new Map();
-    this._messages = new Map();
-  }
-
-  _getCustodyAddresses() {
-    return this._custodyAddresses;
+    this._custodyAdds = new Map();
+    this._custodyRemoves = new Map();
+    this._signerAdds = new Map();
+    this._signerRemoves = new Map();
   }
 
   _getCustodyAdds() {
@@ -503,28 +272,12 @@ class SignerSet {
     return this._custodyRemoves;
   }
 
-  _getVertexAdds() {
-    return this._vertexAdds;
+  _getSignerAdds() {
+    return this._signerAdds;
   }
 
-  _getVertexRemoves() {
-    return this._vertexRemoves;
-  }
-
-  _getEdgeAdds() {
-    return this._edgeAdds;
-  }
-
-  _getEdgeRemoves() {
-    return this._edgeRemoves;
-  }
-
-  _getEdges() {
-    return this._edges;
-  }
-
-  _getMessages() {
-    return this._messages;
+  _getSignerRemoves() {
+    return this._signerRemoves;
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,7 +38,8 @@ export type Body =
   | VerificationAddBody
   | VerificationRemoveBody
   | SignerAddBody
-  | SignerRemoveBody;
+  | SignerRemoveBody
+  | CustodyRemoveAllBody;
 
 // ===========================
 //  Root Types
@@ -261,6 +262,24 @@ export type SignerRemove = Message<SignerRemoveBody>;
 export type SignerRemoveBody = {
   childKey: string;
   schema: 'farcaster.xyz/schemas/v1/signer-remove';
+};
+
+/** CustodyRemoveAll message */
+export type CustodyRemoveAll = Message<CustodyRemoveAllBody>;
+
+/**
+ * A CustodyRemoveAllBody represents the removal of all custody addresses before a given block
+ */
+export type CustodyRemoveAllBody = {
+  schema: 'farcaster.xyz/schemas/v1/custody-remove-all';
+};
+
+/**
+ * A CustodyAddEvent represents an event from the ID contract
+ */
+export type CustodyAddEvent = {
+  custodyAddress: string;
+  blockNumber: number;
 };
 
 // ===========================

--- a/src/types/typeguards.ts
+++ b/src/types/typeguards.ts
@@ -1,15 +1,15 @@
 import * as FC from '~/types';
 
-export function isRoot(msg: FC.Message): msg is FC.Root {
+export const isRoot = (msg: FC.Message): msg is FC.Root => {
   const body = (msg as FC.Root).data?.body;
   return body && body.schema === 'farcaster.xyz/schemas/v1/root' && typeof body.blockHash == 'string';
-}
+};
 
-export function isCast(msg: FC.Message): msg is FC.Cast {
+export const isCast = (msg: FC.Message): msg is FC.Cast => {
   return isCastShort(msg) || isCastRemove(msg) || isCastRecast(msg);
-}
+};
 
-export function isCastShort(msg: FC.Message): msg is FC.CastShort {
+export const isCastShort = (msg: FC.Message): msg is FC.CastShort => {
   const body = (msg as FC.CastShort).data?.body;
   return (
     body &&
@@ -18,19 +18,19 @@ export function isCastShort(msg: FC.Message): msg is FC.CastShort {
     !!body.embed &&
     Array.isArray(body.embed.items)
   );
-}
+};
 
-export function isCastRemove(msg: FC.Message): msg is FC.CastRemove {
+export const isCastRemove = (msg: FC.Message): msg is FC.CastRemove => {
   const body = (msg as FC.CastRemove).data?.body;
   return body && body.schema === 'farcaster.xyz/schemas/v1/cast-remove' && typeof body.targetHash === 'string';
-}
+};
 
-export function isCastRecast(msg: FC.Message): msg is FC.CastRecast {
+export const isCastRecast = (msg: FC.Message): msg is FC.CastRecast => {
   const body = (msg as FC.CastRecast).data?.body;
   return body && body.schema === 'farcaster.xyz/schemas/v1/cast-recast' && typeof body.targetCastUri === 'string';
-}
+};
 
-export function isReaction(msg: FC.Message): msg is FC.Reaction {
+export const isReaction = (msg: FC.Message): msg is FC.Reaction => {
   const body = (msg as FC.Reaction).data?.body;
   return (
     body &&
@@ -39,9 +39,9 @@ export function isReaction(msg: FC.Message): msg is FC.Reaction {
     typeof body.targetUri === 'string' &&
     body.type === 'like'
   );
-}
+};
 
-export function isSignerAdd(msg: FC.Message): msg is FC.SignerAdd {
+export const isSignerAdd = (msg: FC.Message): msg is FC.SignerAdd => {
   const body = (msg as FC.SignerAdd).data?.body;
   return (
     body &&
@@ -52,18 +52,23 @@ export function isSignerAdd(msg: FC.Message): msg is FC.SignerAdd {
     typeof body.edgeHash === 'string' &&
     body.edgeHash.length > 0
   );
-}
+};
 
-export function isSignerRemove(msg: FC.Message): msg is FC.SignerRemove {
+export const isSignerRemove = (msg: FC.Message): msg is FC.SignerRemove => {
   const body = (msg as FC.SignerRemove).data?.body;
   return body && body.schema === 'farcaster.xyz/schemas/v1/signer-remove' && typeof body.childKey === 'string';
-}
+};
 
-export function isVerification(msg: FC.Message): msg is FC.Verification {
+export const isCustodyRemoveAll = (msg: FC.Message): msg is FC.CustodyRemoveAll => {
+  const body = (msg as FC.CustodyRemoveAll).data?.body;
+  return body && body.schema === 'farcaster.xyz/schemas/v1/custody-remove-all';
+};
+
+export const isVerification = (msg: FC.Message): msg is FC.Verification => {
   return isVerificationAdd(msg) || isVerificationRemove(msg);
-}
+};
 
-export function isVerificationAdd(msg: FC.Message): msg is FC.VerificationAdd {
+export const isVerificationAdd = (msg: FC.Message): msg is FC.VerificationAdd => {
   const body = (msg as FC.VerificationAdd).data?.body;
   return (
     body &&
@@ -74,9 +79,9 @@ export function isVerificationAdd(msg: FC.Message): msg is FC.VerificationAdd {
     typeof body.claimHash === 'string' &&
     body.claimHash.length > 0
   );
-}
+};
 
-export function isVerificationRemove(msg: FC.Message): msg is FC.VerificationRemove {
+export const isVerificationRemove = (msg: FC.Message): msg is FC.VerificationRemove => {
   const body = (msg as FC.VerificationRemove).data?.body;
   return (
     body &&
@@ -84,4 +89,4 @@ export function isVerificationRemove(msg: FC.Message): msg is FC.VerificationRem
     typeof body.claimHash === 'string' &&
     body.claimHash.length > 0
   );
-}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4173,6 +4173,11 @@ through@^2.3.8:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
+tiny-typed-emitter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz#b3b027fdd389ff81a152c8e847ee2f5be9fad7b5"
+  integrity sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==
+
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"


### PR DESCRIPTION
Implements idea 2 from https://www.notion.so/farcasterxyz/Signer-set-cut-back-ideas-afb8ca2b1d7543a6ad1164425b264c14

Summary of changes:
- Add data structure (`CustodyAddEvent`) representing FIR events (i.e. transfer and register)
- Add `CustodyRemoveAll` message type, which removes all custody addresses prior to the custody address signing this message
- Only allow custody addresses to add/remove delegate signers
- Drop vertices/edges data structure in favor of LWW set for delegate signers
- Add comment at top of SignerSet with explanation of sets and conflict resolution logic (custody block number, remove > add, custody address lexicographical order, message hash lexicographical order)
- Add [tiny-typed-emitter](https://github.com/binier/tiny-typed-emitter) library for typing event emitters
- Make SignerSet an event emitter and specify supported events in `SignerSetEvents`
- When a custody address is removed, drop all messages signed by that address and emit resulting events (i.e. `removeSigner` when SignerAdd message is dropped)
- Re-write SignerSet tests and check full set state (`custodyAdds`, `custodyRemoves`, `signerAdds`, `signerRemoves`, and ordered list of emitted events)